### PR TITLE
feat: implement multi-page WebSocket routing

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -253,7 +253,10 @@ func (s *Server) serveWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[WS] WebSocket connection for page: %s (pattern: %s)", pagePath, route.Pattern)
 
-	// Create WebSocket handler for this page
+	// Create a new WebSocketHandler instance for this connection.
+	// NOTE: Each WebSocket connection (e.g., each browser tab) gets its own
+	// handler with isolated state. Interactive state is intentionally NOT
+	// synchronized across multiple connections to the same page.
 	wsHandler := NewWebSocketHandler(route.Page, s, true, s.rootDir, s.config)
 	wsHandler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
## Summary
- Route WebSocket connections to the correct page based on a `page` query parameter
- Each page in a documentation site now maintains its own interactive state
- Falls back to first route for backward compatibility when page parameter is missing

## Test plan
- [x] Run all tests: `go test ./...` - all pass
- [x] Unit tests verify WebSocket URL contains correct page parameter
- [x] Unit tests verify page routing logic (default, specific page, fallback)

This implements roadmap item **2.3 Multi-Page WebSocket Support**, enabling documentation sites with interactive examples on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)