### PR TITLE
fix: add --no-sandbox flag for chromedp tests in CI

### DIFF
--- a/action_buttons_e2e_test.go
+++ b/action_buttons_e2e_test.go
@@ -47,6 +47,7 @@ func TestActionButtons(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/component_library_e2e_test.go
+++ b/component_library_e2e_test.go
@@ -40,6 +40,7 @@ func TestAutoTableRendering(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/computed_expressions_e2e_test.go
+++ b/computed_expressions_e2e_test.go
@@ -53,6 +53,7 @@ func TestComputedExpressions(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/exec_toolbar_e2e_test.go
+++ b/exec_toolbar_e2e_test.go
@@ -64,6 +64,7 @@ func TestExecToolbarManualMode(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 
@@ -377,6 +378,7 @@ func TestExecToolbarAutoMode(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/execargs_e2e_test.go
+++ b/execargs_e2e_test.go
@@ -66,6 +66,7 @@ func TestExecArgsForm(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/frontmatter_config_e2e_test.go
+++ b/frontmatter_config_e2e_test.go
@@ -33,6 +33,7 @@ func TestFrontmatterSources(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/lvtsource_e2e_test.go
+++ b/lvtsource_e2e_test.go
@@ -60,6 +60,7 @@ func TestLvtSourceExec(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/lvtsource_file_e2e_test.go
+++ b/lvtsource_file_e2e_test.go
@@ -52,6 +52,7 @@ func TestLvtSourceJSON(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 
@@ -155,6 +156,7 @@ func TestLvtSourceCSV(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/lvtsource_graphql_e2e_test.go
+++ b/lvtsource_graphql_e2e_test.go
@@ -57,6 +57,7 @@ func TestGraphQLSourceE2E(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/lvtsource_markdown_e2e_test.go
+++ b/lvtsource_markdown_e2e_test.go
@@ -168,6 +168,7 @@ func setupMarkdownTestInternal(t *testing.T, exampleDir string, enableWatch bool
 	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 
 	ctx, ctxCancel := chromedp.NewContext(allocCtx, chromedp.WithLogf(t.Logf))
@@ -213,6 +214,7 @@ func TestLvtSourceMarkdownTaskList(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/lvtsource_pg_e2e_test.go
+++ b/lvtsource_pg_e2e_test.go
@@ -83,6 +83,7 @@ func TestLvtSourcePostgres(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/lvtsource_rest_e2e_test.go
+++ b/lvtsource_rest_e2e_test.go
@@ -132,6 +132,7 @@ title: "REST API Test"
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/lvtsource_sqlite_e2e_test.go
+++ b/lvtsource_sqlite_e2e_test.go
@@ -49,6 +49,7 @@ func TestLvtSourceSQLite(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/partials_e2e_test.go
+++ b/partials_e2e_test.go
@@ -39,6 +39,7 @@ func TestPartials(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/search_e2e_test.go
+++ b/search_e2e_test.go
@@ -41,6 +41,7 @@ func TestSearchFunctionality(t *testing.T) {
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
 			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
 		)...)
 	defer cancel()
 

--- a/ux_enhancements_e2e_test.go
+++ b/ux_enhancements_e2e_test.go
@@ -229,6 +229,7 @@ func TestResponsiveLayout(t *testing.T) {
 			// Create chromedp context with specific viewport
 			opts := append(chromedp.DefaultExecAllocatorOptions[:],
 				chromedp.WindowSize(vp.width, vp.height),
+				chromedp.Flag("no-sandbox", true),
 			)
 
 			allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)


### PR DESCRIPTION
## Summary

Chrome fails with "No usable sandbox" error on Ubuntu 23.10+ due to AppArmor restrictions on unprivileged user namespaces. This breaks E2E tests in CI environments like GitHub Actions.

## Changes

- Adds `--no-sandbox` flag to all E2E test files that were missing it
- 16 files updated with `chromedp.Flag("no-sandbox", true)` 

## Design Decision

Initially, a `NewChromedpAllocator()` helper function was considered to centralize the CI detection logic. However, this approach was abandoned because:

1. **Package Constraints**: E2E tests are split across two packages:
   - `package tinkerdown` (white-box tests): mermaid_diagrams_e2e_test.go, presentation_mode_e2e_test.go
   - `package tinkerdown_test` (black-box tests): most other E2E tests
   
   A helper in one package cannot be imported by tests in the other package without creating a separate internal package (which adds complexity for minimal benefit).

2. **Simplicity**: The direct flag addition is straightforward, easy to audit, and doesn't introduce additional abstraction layers.

3. **Test-only Code**: The `--no-sandbox` flag is only used in test files (which are excluded from production builds). The security trade-off is acceptable in test environments where we're running controlled test scenarios, not browsing untrusted content.

## Coverage

Files already had `--no-sandbox` before this PR:
- mermaid_diagrams_e2e_test.go
- presentation_mode_e2e_test.go
- tutorial_nav_bug_test.go

Files updated by this PR (16 files):
- action_buttons_e2e_test.go, component_library_e2e_test.go, computed_expressions_e2e_test.go, exec_toolbar_e2e_test.go, execargs_e2e_test.go, frontmatter_config_e2e_test.go, lvtsource_e2e_test.go, lvtsource_file_e2e_test.go, lvtsource_graphql_e2e_test.go, lvtsource_markdown_e2e_test.go, lvtsource_pg_e2e_test.go, lvtsource_rest_e2e_test.go, lvtsource_sqlite_e2e_test.go, partials_e2e_test.go, search_e2e_test.go, ux_enhancements_e2e_test.go

## Background

This issue was discovered while running cross-repo tests for livetemplate/livetemplate PR #86. The Tinkerdown E2E tests were failing in CI with:

```
No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor...
```

See: https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md

## Test plan

- [x] Verify E2E tests pass in CI with this fix
- [x] Verify E2E tests still work locally