### PR TITLE
fix: add --no-sandbox to remaining chromedp tests

### DIFF
--- a/build_command_e2e_test.go
+++ b/build_command_e2e_test.go
@@ -288,7 +288,15 @@ This page was served from a standalone binary.
 	t.Logf("HTTP GET /app status: %d", resp.StatusCode)
 
 	// Test with chromedp with its own timeout
-	chromeCtx, chromeCancel := chromedp.NewContext(ctx)
+	// Use NewExecAllocator with no-sandbox for CI environments
+	allocCtx, allocCancel := chromedp.NewExecAllocator(ctx,
+		append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.Flag("headless", true),
+			chromedp.Flag("no-sandbox", true),
+		)...)
+	defer allocCancel()
+
+	chromeCtx, chromeCancel := chromedp.NewContext(allocCtx)
 	defer chromeCancel()
 
 	chromeCtx, chromeTimeout := context.WithTimeout(chromeCtx, 30*time.Second)

--- a/ux_enhancements_e2e_test.go
+++ b/ux_enhancements_e2e_test.go
@@ -72,8 +72,15 @@ func TestUXEnhancements(t *testing.T) {
 	})
 
 	t.Run("ImprovedLayoutWidths", func(t *testing.T) {
-		// Create chromedp context
-		ctx, cancel := chromedp.NewContext(context.Background())
+		// Create chromedp context with no-sandbox for CI environments
+		allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
+			append(chromedp.DefaultExecAllocatorOptions[:],
+				chromedp.Flag("headless", true),
+				chromedp.Flag("no-sandbox", true),
+			)...)
+		defer cancel()
+
+		ctx, cancel := chromedp.NewContext(allocCtx)
 		defer cancel()
 
 		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
@@ -115,8 +122,15 @@ func TestUXEnhancements(t *testing.T) {
 	})
 
 	t.Run("MonacoLazyLoading", func(t *testing.T) {
-		// Create chromedp context
-		ctx, cancel := chromedp.NewContext(context.Background())
+		// Create chromedp context with no-sandbox for CI environments
+		allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
+			append(chromedp.DefaultExecAllocatorOptions[:],
+				chromedp.Flag("headless", true),
+				chromedp.Flag("no-sandbox", true),
+			)...)
+		defer cancel()
+
+		ctx, cancel := chromedp.NewContext(allocCtx)
 		defer cancel()
 
 		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)


### PR DESCRIPTION
## Summary

Follow-up to PR #115. Some E2E tests were still using `chromedp.NewContext()` directly without `NewExecAllocator`, which meant they didn't receive the `--no-sandbox` flag needed for CI environments on Ubuntu 23.10+.

## Changes

Fixed tests that were missing the proper exec allocator setup:

- **ux_enhancements_e2e_test.go**: 
  - `ImprovedLayoutWidths` test
  - `MonacoLazyLoading` test

- **build_command_e2e_test.go**:
  - `TestBuildCommandRunsServer` test

## Root Cause

These tests used the pattern:
```go
ctx, cancel := chromedp.NewContext(context.Background())
```

Instead of the correct pattern:
```go
allocCtx, cancel := chromedp.NewExecAllocator(context.Background(),
    append(chromedp.DefaultExecAllocatorOptions[:],
        chromedp.Flag("headless", true),
        chromedp.Flag("no-sandbox", true),
    )...)
defer cancel()

ctx, cancel := chromedp.NewContext(allocCtx)
```

## Test plan

- [x] Verify affected tests pass locally
- [ ] Verify CI passes