### PR TITLE
feat: add Docker support with multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,8 +32,11 @@ Thumbs.db
 # Test artifacts
 testdata/tmp/
 *.sqlite
+*.sqlite-*
 coverage.out
 coverage.html
+*.log
+.env*
 
 # Development files
 .claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,14 @@ COPY client/ ./
 RUN npm run build
 
 # Build stage 2: Build Go binary
-FROM golang:1.24-alpine AS go-builder
+FROM golang:1.25-alpine AS go-builder
 
 # Install git for version info and ca-certificates for HTTPS
 RUN apk add --no-cache git ca-certificates
 
 WORKDIR /app
 
-# Allow Go to download required toolchain version automatically
+# Allow Go to download required toolchain version if go.mod specifies newer
 ENV GOTOOLCHAIN=auto
 
 # Copy go mod files first for better caching
@@ -26,10 +26,13 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Copy built client assets from previous stage
+# Copy built client assets from previous stage (JS, CSS, and source maps)
 COPY --from=client-builder /app/client/dist/ ./client/dist/
 RUN mkdir -p internal/assets/client && \
-    cp client/dist/tinkerdown-client.browser.* internal/assets/client/
+    cp client/dist/tinkerdown-client.browser.js internal/assets/client/ && \
+    cp client/dist/tinkerdown-client.browser.js.map internal/assets/client/ && \
+    cp client/dist/tinkerdown-client.browser.css internal/assets/client/ && \
+    cp client/dist/tinkerdown-client.browser.css.map internal/assets/client/
 
 # Build with optimizations and version info
 ARG VERSION=dev


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile for containerized deployment
- Add .dockerignore for efficient builds
- Final image size: 34MB (under 50MB target)

## Details

**3-stage build:**
1. `node:20-alpine` - builds TypeScript client
2. `golang:1.24-alpine` - compiles Go binary
3. `alpine:3.21` - minimal runtime (34MB)

**Features:**
- Non-root user for security
- `GOTOOLCHAIN=auto` for Go version compatibility
- Volume mounts work with live reload
- ca-certificates and tzdata included

## Usage

```bash
# Build
docker build -t tinkerdown .

# Run with volume mount
docker run -v $(pwd):/app -p 8080:8080 tinkerdown
```

## Test plan

- [x] Docker image builds successfully
- [x] Image size under 50MB (34.1MB)
- [x] Volume mounts work
- [x] Live reload works with mounted files
- [x] Server accessible from host via port mapping
- [ ] Publish to registry (follow-up task)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)