### PR TITLE
chore: upgrade Go to 1.26

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: '1.25.3'
+  GO_VERSION: '1.26.0'
 
 jobs:
   build:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: '1.25.3'
+  GO_VERSION: '1.26.0'
   NODE_VERSION: '20'
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY client/ ./
 RUN npm run build
 
 # Build stage 2: Build Go binary
-FROM golang:1.25-alpine AS go-builder
+FROM golang:1.26-alpine AS go-builder
 
 # Install git for version info and ca-certificates for HTTPS
 RUN apk add --no-cache git ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livetemplate/tinkerdown
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -1,14 +1,3 @@
 module github.com/livetemplate/tinkerdown/tests/e2e
 
-go 1.25.3
-
-require (
-	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // indirect
-	github.com/chromedp/chromedp v0.14.2 // indirect
-	github.com/chromedp/sysutil v1.1.0 // indirect
-	github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 // indirect
-	github.com/gobwas/httphead v0.1.0 // indirect
-	github.com/gobwas/pool v0.2.1 // indirect
-	github.com/gobwas/ws v1.4.0 // indirect
-	golang.org/x/sys v0.34.0 // indirect
-)
+go 1.26.0


### PR DESCRIPTION
## Summary
- Upgrade Go to 1.26.0 in go.mod and tests/e2e/go.mod
- Update CI workflow Go versions to 1.26.0 (cli-release.yml, desktop-release.yml)
- Update Dockerfile base image to golang:1.26-alpine
- ci.yml already uses go-version-file: 'go.mod' (auto-reads version)

## Test plan
- [x] `go mod tidy` completes without errors
- [x] `go test ./...` passes (unit tests)
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)