### PR TITLE
feat: sharded rate limiter with benchmarks

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/livetemplate/tinkerdown/internal/config"
 
@@ -247,6 +248,10 @@ type shard struct {
 	evictCount   int
 	_            [64]byte // pad to 128 bytes (2 cache lines) to reduce false sharing
 }
+
+// Compile-time assertion: shard struct must be exactly 128 bytes.
+// If a field is added/changed, adjust the padding to maintain cache-line alignment.
+const _ = uint(128 - unsafe.Sizeof(shard{}))
 
 // shardedRateLimiter distributes IPs across multiple shards to reduce
 // mutex contention under parallel load.

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -448,8 +448,10 @@ func BenchmarkRateLimit_UniqueIPs(b *testing.B) {
 	}
 }
 
-// BenchmarkRateLimit_Parallel measures contention: multiple goroutines, 100 IPs each.
-func BenchmarkRateLimit_Parallel(b *testing.B) {
+// BenchmarkRateLimit_Parallel_SingleMutex measures single-mutex contention:
+// multiple goroutines, 100 IPs each. Uses the single-mutex path directly
+// (not the public API) to establish a baseline for comparison with sharded.
+func BenchmarkRateLimit_Parallel_SingleMutex(b *testing.B) {
 	for _, maxIPs := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprintf("MaxIPs_%d", maxIPs), func(b *testing.B) {
 			handler, cleanup := benchRateLimitHandler(b, 1e9, 1<<30, maxIPs)


### PR DESCRIPTION
## Summary

- **Sharded rate limiter (#155):** Replaces single-mutex implementation with a 16-shard design using FNV-1a IP hashing. Each shard has its own mutex, LRU list, and eviction state. Token bucket Allow() is called outside the critical section to minimize lock hold time. Falls back to single-mutex for maxIPs < 16 to avoid zero-capacity shards.
- **Rate limiter benchmarks (#154):** Adds comprehensive benchmarks covering single-IP hot path, unique-IP inserts with eviction, parallel contention at varying maxIPs, single-mutex vs sharded comparison, and varying shard counts (1/4/8/16/32).
- Public API (RateLimitMiddleware) is unchanged — sharding is an internal optimization.

Closes #154, closes #155.

## Benchmark results (Apple M2, 8 cores)

These benchmarks establish a baseline for the rate limiter throughput. At 8 cores with 100 cycling IPs, the workload does not saturate the single mutex, so both paths perform similarly. The sharding benefit is expected to manifest under higher core counts and insertion-heavy workloads.

```
BenchmarkRateLimit_SingleIP-8                                       6424330    177 ns/op     8 B/op    1 allocs/op
BenchmarkRateLimit_UniqueIPs-8                                       673437   1969 ns/op  5385 B/op   16 allocs/op
BenchmarkRateLimit_Parallel_SingleMutex/MaxIPs_100-8                 853477   1188 ns/op  5202 B/op   13 allocs/op
BenchmarkRateLimit_Parallel_SingleMutex/MaxIPs_1000-8               1000000   1234 ns/op  5202 B/op   13 allocs/op
BenchmarkRateLimit_Parallel_SingleMutex/MaxIPs_10000-8              1000000   1137 ns/op  5202 B/op   13 allocs/op
BenchmarkRateLimit_Comparison/SingleMutex-8                         1000000   1383 ns/op  5202 B/op   13 allocs/op
BenchmarkRateLimit_Comparison/Sharded16-8                            993960   1274 ns/op  5202 B/op   13 allocs/op
BenchmarkShardedRateLimit_VaryingShards/Shards_1-8                   956486   1183 ns/op  5202 B/op   13 allocs/op
BenchmarkShardedRateLimit_VaryingShards/Shards_4-8                  1000000   1171 ns/op  5202 B/op   13 allocs/op
BenchmarkShardedRateLimit_VaryingShards/Shards_8-8                  1000000   1378 ns/op  5202 B/op   13 allocs/op
BenchmarkShardedRateLimit_VaryingShards/Shards_16-8                  898264   1243 ns/op  5202 B/op   13 allocs/op
BenchmarkShardedRateLimit_VaryingShards/Shards_32-8                  945973   1181 ns/op  5202 B/op   13 allocs/op
```

## Test plan

- [x] All existing rate limiter tests pass (they now exercise the sharded path for maxIPs >= 16)
- [x] TestShardedRateLimitTotalCapacity — verifies eviction works and evicted IPs get fresh limiters (deterministic shard targeting)
- [x] TestShardedRateLimitCleanup — verifies cleanup goroutine sweeps stale entries across all shards
- [x] TestShardedRateLimitBoundary — verifies maxIPs == defaultNumShards boundary (capacity-1 shards)
- [x] TestShardedRateLimitFallback — verifies maxIPs < 16 falls back to single-mutex
- [x] All tests pass with -race flag (including -race -bench=. for parallel benchmarks)
- [x] go vet ./... clean