### PR TITLE
ci: add smoke test after building release binaries

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -70,8 +70,9 @@ jobs:
 
       - name: Smoke test
         run: |
-          ./tinkerdown version
-          ./tinkerdown version | grep -q "${{ steps.version.outputs.version }}"
+          VERSION_OUT=$(./tinkerdown version)
+          echo "$VERSION_OUT"
+          echo "$VERSION_OUT" | grep -Fq "${{ steps.version.outputs.version }}"
           ./tinkerdown help
 
       - name: Create archive


### PR DESCRIPTION
## Summary

- Adds a smoke test step to the CLI release workflow between "Build binary" and "Create archive"
- Verifies the binary executes (`./tinkerdown version`), reports the correct ldflags-injected version, and handles `help`
- Runs natively on each platform's build runner (macos-13, macos-14, ubuntu-latest)

Closes #128

## Test plan

- [ ] Review the workflow diff — single step insertion, no other changes
- [ ] Verify on next release tag push or manual `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)