### PR TITLE
feat: add DNS result caching for webhook SSRF validation

### DIFF
--- a/internal/security/url.go
+++ b/internal/security/url.go
@@ -58,8 +58,10 @@ func (c *dnsCache) set(host string, err error) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	now := time.Now()
 	if len(c.entries) >= c.maxSize {
-		now := time.Now()
+		// Prune expired entries first (O(n) scan under write lock;
+		// acceptable at the current 1024 cap and rarely triggered).
 		for k, v := range c.entries {
 			if now.After(v.expiresAt) {
 				delete(c.entries, k)
@@ -76,13 +78,17 @@ func (c *dnsCache) set(host string, err error) {
 	}
 	c.entries[host] = dnsCacheEntry{
 		err:       err,
-		expiresAt: time.Now().Add(c.ttl),
+		expiresAt: now.Add(c.ttl),
 	}
 }
 
 // ValidateHTTPURL checks for SSRF vulnerabilities by blocking requests to internal networks.
 // It rejects localhost, private IP ranges, link-local addresses, and cloud metadata endpoints.
 // Hostnames are resolved to detect DNS rebinding attacks targeting internal addresses.
+//
+// Blocked results are cached for up to 30 seconds. If a hostname transiently resolves to an
+// internal address (e.g. during DNS propagation), it will remain blocked until the cache entry
+// expires, even if the DNS record is corrected sooner.
 func ValidateHTTPURL(rawURL string) error {
 	if testBypassSSRF.Load() {
 		return nil

--- a/internal/security/url_test.go
+++ b/internal/security/url_test.go
@@ -166,9 +166,9 @@ func TestDNSCache_MaxSizePrunesExpired(t *testing.T) {
 	}
 
 	// Cache should have only 1 entry (d.com) since expired ones were pruned.
-	c.mu.Lock()
+	c.mu.RLock()
 	size := len(c.entries)
-	c.mu.Unlock()
+	c.mu.RUnlock()
 	if size != 1 {
 		t.Fatalf("expected 1 entry after pruning, got %d", size)
 	}


### PR DESCRIPTION
## Summary
- Adds a 30s TTL DNS validation cache to `ValidateHTTPURL` in `internal/security/url.go` to cache **blocked** (error) results only, reducing redundant `net.LookupHost` calls for repeated webhook validations against hostnames that resolve to internal addresses
- Allowed results are never cached — hosts are always re-validated to prevent DNS rebinding attacks
- Cache is concurrent-safe (`sync.RWMutex`), bounded (1024 entries), with two-phase eviction (prune expired → single-entry eviction)
- Test helper `resetDNSCache()` (unexported, test file only) for test isolation

## Test plan
- [x] `TestDNSCache_HitAndExpiry` — verifies cache hit returns stored error, TTL expiry causes miss
- [x] `TestDNSCache_MaxSize` — verifies single-entry eviction when at capacity
- [x] `TestDNSCache_MaxSizePrunesExpired` — verifies expired entries are pruned before eviction
- [x] `TestDNSCache_ConcurrentAccess` — parallel reads/writes pass `-race` detector
- [x] All existing `TestValidateHTTPURL*` tests pass with cache integration
- [x] `go test -race -short ./internal/...` — no regressions
- [x] `go vet ./...` — clean

Closes #141