### PR TITLE
test: add XSS escaping E2E test for auto-task templates

### DIFF
--- a/auto_tasks_e2e_test.go
+++ b/auto_tasks_e2e_test.go
@@ -658,16 +658,23 @@ func TestAutoTasks_XSSEscaping(t *testing.T) {
 	// The payloads set window.__xssExecutedScript / window.__xssExecutedImg
 	// if they execute. This is deterministic — unlike console log scanning,
 	// it directly detects whether the browser ran the injected code.
-	var scriptExecuted, imgExecuted bool
+	var scriptExecuted bool
 	err = chromedp.Run(ctx,
 		chromedp.Evaluate(`window.__xssExecutedScript === true`, &scriptExecuted),
-		chromedp.Evaluate(`window.__xssExecutedImg === true`, &imgExecuted),
 	)
 	if err != nil {
-		t.Fatalf("Failed to check XSS sentinel flags: %v", err)
+		t.Fatalf("Failed to check script sentinel flag: %v", err)
 	}
 	if scriptExecuted {
 		t.Fatal("XSS: <script> payload executed — window.__xssExecutedScript was set!")
+	}
+
+	var imgExecuted bool
+	err = chromedp.Run(ctx,
+		chromedp.Evaluate(`window.__xssExecutedImg === true`, &imgExecuted),
+	)
+	if err != nil {
+		t.Fatalf("Failed to check img sentinel flag: %v", err)
 	}
 	if imgExecuted {
 		t.Fatal("XSS: <img onerror> payload executed — window.__xssExecutedImg was set!")


### PR DESCRIPTION
## Summary
- Adds `TestAutoTasks_XSSEscaping` E2E test that verifies XSS payloads in task item text (`<script>`, `<img onerror>`, HTML entities) are escaped by `html/template` and rendered as visible text, not live HTML
- Guards against regressions like accidentally switching to `text/template`
- Checks DOM for absence of injected elements (`<script>`, `<img>`, `<b>`) and console logs for absence of script execution

Closes #146

## Test plan
- [x] `go test -v -run TestAutoTasks_XSSEscaping ./...` passes
- [x] `GOWORK=off go test -race -short ./internal/...` — no regressions
- [x] `GOWORK=off go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)