### PR TITLE
docs: document API authentication config (#140)

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -145,6 +145,8 @@ api:
     header_name: Authorization  # Expects "Authorization: Bearer <token>"
 ```
 
+When using `Authorization`, clients send `Authorization: Bearer <token>` and the middleware strips the `Bearer ` prefix before matching. Set `api_key` (or `keys[].key`) to the **raw token value**, not the full `Bearer ...` string.
+
 > **Secure default:** If any key (`api_key` or `keys[].key`) references an environment variable that is **not set**, authentication is still treated as **enabled**. The expanded key is empty, so no request can match it and all API requests are rejected. Auth is never silently disabled by a missing env var.
 
 ### CORS


### PR DESCRIPTION
## Summary
- Add **API Configuration** section to `docs/reference/config.md` covering the full `api:` block: auth, CORS, and rate limiting
- Document both legacy single-key and multi-key-with-permissions authentication
- Document the secure default from PR #138: when `api_key` references an unset env var, auth stays enabled and all requests are rejected
- Update the Full Schema snippet to include the `api:` block

## Test plan
- [x] Verified documented config fields match `internal/config/config.go` structs
- [x] `go test -short ./internal/...` — all pass
- [x] `go vet ./...` — clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)