### PR TITLE
ci: skip heavy workflows for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   test-go:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` for `docs/**`, `**/*.md`, and `LICENSE` to the `ci.yml` workflow (both `push` and `pull_request` triggers)
- Bot reviewer workflows (`claude-code-review.yml`, `claude.yml`) are intentionally unchanged
- Release workflows (`cli-release.yml`, `desktop-release.yml`) are tag-triggered, no changes needed

## Test plan
- [x] Verify `paths-ignore` patterns are present in `ci.yml`
- [x] Verify bot reviewer workflows are not modified
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)