### PR TITLE
feat: schema introspection for auto-table form inputs

### DIFF
--- a/auto_tables.go
+++ b/auto_tables.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/livetemplate/tinkerdown/internal/slug"
+	"github.com/livetemplate/tinkerdown/internal/source"
 )
 
 // tableSection represents a detected markdown table under a heading.
@@ -138,9 +139,10 @@ func parseTableColumns(headerContent string) []string {
 
 // matchResult represents a successful source match for a table section.
 type matchResult struct {
-	section    tableSection
-	sourceName string
-	writable   bool
+	section     tableSection
+	sourceName  string
+	writable    bool
+	columnTypes map[string]string // column name → normalized type (from schema introspection)
 }
 
 // matchTablesToSources matches detected table sections to declared sources.
@@ -268,7 +270,7 @@ func isWritable(src SourceConfig) bool {
 //   - Tier 1: markdown tables + yaml sources → interactive data tables + CRUD
 //
 // The function does NOT modify the original file — it operates on in-memory content.
-func preprocessAutoTables(content []byte, sources map[string]SourceConfig) ([]byte, []string) {
+func preprocessAutoTables(content []byte, sources map[string]SourceConfig, siteDir string) ([]byte, []string) {
 	if len(sources) == 0 {
 		return content, nil
 	}
@@ -288,6 +290,21 @@ func preprocessAutoTables(content []byte, sources map[string]SourceConfig) ([]by
 	matches, warnings := matchTablesToSources(sections, sources)
 	if len(matches) == 0 {
 		return content, warnings
+	}
+
+	// Query schema for sources that support it (currently SQLite)
+	for i := range matches {
+		m := &matches[i]
+		srcCfg := sources[m.sourceName]
+		if srcCfg.Type == "sqlite" && srcCfg.DB != "" && srcCfg.Table != "" {
+			schema := source.QuerySQLiteSchema(srcCfg.DB, srcCfg.Table, siteDir)
+			if len(schema) > 0 {
+				m.columnTypes = make(map[string]string)
+				for _, col := range schema {
+					m.columnTypes[strings.ToLower(col.Name)] = col.Type
+				}
+			}
+		}
 	}
 
 	lines := strings.Split(string(content), "\n")
@@ -310,7 +327,7 @@ func preprocessAutoTables(content []byte, sources map[string]SourceConfig) ([]by
 			}
 		}
 
-		lvtBlock := generateAutoTableLvtBlock(m.sourceName, displayColumns, m.writable)
+		lvtBlock := generateAutoTableLvtBlock(m.sourceName, displayColumns, m.writable, m.columnTypes)
 
 		// Build replacement: heading + lvt code block
 		headingIdx := m.section.headingLine + fmLineCount
@@ -337,11 +354,26 @@ func preprocessAutoTables(content []byte, sources map[string]SourceConfig) ([]by
 //
 // For writable sources: table with edit/delete per row + add form.
 // For read-only sources: table with refresh button.
-func generateAutoTableLvtBlock(sourceName string, columns []string, writable bool) string {
+// generateAutoTableLvtBlock generates the lvt template HTML for an auto-table section.
+// columnTypes maps lowercase column names to normalized types (e.g., "integer", "real").
+// If nil, all inputs default to type="text".
+func generateAutoTableLvtBlock(sourceName string, columns []string, writable bool, columnTypes map[string]string) string {
 	if writable {
-		return generateWritableTableBlock(sourceName, columns)
+		return generateWritableTableBlock(sourceName, columns, columnTypes)
 	}
 	return generateReadonlyTableBlock(sourceName, columns)
+}
+
+// inputTypeFor returns the HTML input type for a column, using schema info if available.
+func inputTypeFor(colName string, columnTypes map[string]string) string {
+	if columnTypes == nil {
+		return "text"
+	}
+	colType, ok := columnTypes[strings.ToLower(colName)]
+	if !ok {
+		return "text"
+	}
+	return source.InputTypeForColumn(colType)
 }
 
 // generateReadonlyTableBlock generates an auto-rendered read-only table.
@@ -402,7 +434,7 @@ func generateReadonlyTableBlock(sourceName string, columns []string) string {
 // generateWritableTableBlock generates an auto-rendered writable table with full CRUD.
 // Includes inline editing: each row has Edit/Delete buttons. Clicking Edit replaces
 // the row's cells with input fields and shows Save/Cancel buttons.
-func generateWritableTableBlock(sourceName string, columns []string) string {
+func generateWritableTableBlock(sourceName string, columns []string, columnTypes map[string]string) string {
 	var b strings.Builder
 
 	b.WriteString(fmt.Sprintf(`<div lvt-source="%s">`, sourceName))
@@ -442,7 +474,8 @@ func generateWritableTableBlock(sourceName string, columns []string) string {
 		fieldName := toFieldName(col)
 		inputName := toInputName(col)
 		formID := "auto-table-edit-" + sourceName
-		b.WriteString(fmt.Sprintf(`      <td><input type="text" name="%s" value="{{.%s}}" form="%s"`, inputName, fieldName, formID))
+		iType := inputTypeFor(col, columnTypes)
+		b.WriteString(fmt.Sprintf(`      <td><input type="%s" name="%s" value="{{.%s}}" form="%s"`, iType, inputName, fieldName, formID))
 		b.WriteString("\n")
 		b.WriteString(`        style="width: 100%; padding: 4px 6px; border: 1px solid #007bff; border-radius: 4px; box-sizing: border-box;"></td>`)
 		b.WriteString("\n")
@@ -524,7 +557,8 @@ func generateWritableTableBlock(sourceName string, columns []string) string {
 		b.WriteString("\n")
 		b.WriteString(fmt.Sprintf(`    <label style="font-size: 0.8em; color: #666;">%s</label>`, html.EscapeString(col)))
 		b.WriteString("\n")
-		b.WriteString(fmt.Sprintf(`    <input type="text" name="%s" placeholder="%s..." required`, inputName, html.EscapeString(col)))
+		iType := inputTypeFor(col, columnTypes)
+		b.WriteString(fmt.Sprintf(`    <input type="%s" name="%s" placeholder="%s..." required`, iType, inputName, html.EscapeString(col)))
 		b.WriteString("\n")
 		b.WriteString(`      style="padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px;">`)
 		b.WriteString("\n")

--- a/auto_tables_test.go
+++ b/auto_tables_test.go
@@ -396,7 +396,7 @@ func TestToInputName(t *testing.T) {
 // --- LVT block generation tests ---
 
 func TestGenerateReadonlyBlock(t *testing.T) {
-	block := generateAutoTableLvtBlock("users", []string{"Name", "Email"}, false)
+	block := generateAutoTableLvtBlock("users", []string{"Name", "Email"}, false, nil)
 
 	// Should have lvt-source
 	if !strings.Contains(block, `lvt-source="users"`) {
@@ -425,7 +425,7 @@ func TestGenerateReadonlyBlock(t *testing.T) {
 }
 
 func TestGenerateWritableBlock(t *testing.T) {
-	block := generateAutoTableLvtBlock("expenses", []string{"Description", "Category", "Amount"}, true)
+	block := generateAutoTableLvtBlock("expenses", []string{"Description", "Category", "Amount"}, true, nil)
 
 	// Should have lvt-source
 	if !strings.Contains(block, `lvt-source="expenses"`) {
@@ -482,6 +482,47 @@ func TestGenerateWritableBlock(t *testing.T) {
 	}
 }
 
+func TestGenerateWritableBlockWithSchema(t *testing.T) {
+	// Provide schema types — Amount is REAL, Done is BOOLEAN
+	columnTypes := map[string]string{
+		"description": "text",
+		"amount":      "real",
+		"done":        "boolean",
+		"due":         "date",
+	}
+
+	block := generateAutoTableLvtBlock("tasks", []string{"Description", "Amount", "Done", "Due"}, true, columnTypes)
+
+	// Description should be text input
+	if !strings.Contains(block, `type="text" name="description"`) {
+		t.Error("expected type=\"text\" for Description column")
+	}
+	// Amount should be number input
+	if !strings.Contains(block, `type="number" name="amount"`) {
+		t.Error("expected type=\"number\" for Amount (real) column")
+	}
+	// Done should be checkbox input
+	if !strings.Contains(block, `type="checkbox" name="done"`) {
+		t.Error("expected type=\"checkbox\" for Done (boolean) column")
+	}
+	// Due should be date input
+	if !strings.Contains(block, `type="date" name="due"`) {
+		t.Error("expected type=\"date\" for Due (date) column")
+	}
+}
+
+func TestGenerateWritableBlockWithoutSchema(t *testing.T) {
+	// No schema — all inputs should be text
+	block := generateAutoTableLvtBlock("tasks", []string{"Name", "Amount"}, true, nil)
+
+	if !strings.Contains(block, `type="text" name="name"`) {
+		t.Error("expected type=\"text\" for Name (no schema)")
+	}
+	if !strings.Contains(block, `type="text" name="amount"`) {
+		t.Error("expected type=\"text\" for Amount (no schema)")
+	}
+}
+
 // --- Full preprocessing tests ---
 
 func TestPreprocessAutoTablesExactMatch(t *testing.T) {
@@ -507,7 +548,7 @@ sources:
 		"expenses": {Type: "sqlite", DB: "./test.db", Table: "expenses", Readonly: &readonlyFalse},
 	}
 
-	result, warnings := preprocessAutoTables(content, sources)
+	result, warnings := preprocessAutoTables(content, sources, "")
 	if len(warnings) != 0 {
 		t.Errorf("unexpected warnings: %v", warnings)
 	}
@@ -550,7 +591,7 @@ title: Test
 		"users": {Type: "rest", From: "https://example.com/users"},
 	}
 
-	result, _ := preprocessAutoTables(content, sources)
+	result, _ := preprocessAutoTables(content, sources, "")
 	resultStr := string(result)
 
 	// Should contain Refresh button
@@ -573,7 +614,7 @@ func TestPreprocessAutoTablesNoMatch(t *testing.T) {
 		"expenses": {Type: "sqlite"},
 	}
 
-	result, _ := preprocessAutoTables(content, sources)
+	result, _ := preprocessAutoTables(content, sources, "")
 	resultStr := string(result)
 
 	// Should NOT have lvt code block
@@ -592,7 +633,7 @@ func TestPreprocessAutoTablesNoSources(t *testing.T) {
 |------|-------|
 `)
 
-	result, warnings := preprocessAutoTables(content, nil)
+	result, warnings := preprocessAutoTables(content, nil, "")
 	if len(warnings) != 0 {
 		t.Errorf("unexpected warnings: %v", warnings)
 	}
@@ -617,7 +658,7 @@ func TestPreprocessAutoTablesMultipleSources(t *testing.T) {
 		"contacts": {Type: "sqlite", Readonly: &readonlyFalse},
 	}
 
-	result, warnings := preprocessAutoTables(content, sources)
+	result, warnings := preprocessAutoTables(content, sources, "")
 	if len(warnings) != 0 {
 		t.Errorf("unexpected warnings: %v", warnings)
 	}
@@ -649,7 +690,7 @@ func TestPreprocessAutoTablesContainmentMatch(t *testing.T) {
 		"expenses": {Type: "sqlite"},
 	}
 
-	result, _ := preprocessAutoTables(content, sources)
+	result, _ := preprocessAutoTables(content, sources, "")
 	resultStr := string(result)
 
 	if !strings.Contains(resultStr, `lvt-source="expenses"`) {
@@ -676,7 +717,7 @@ sources:
 		"items": {Type: "sqlite"},
 	}
 
-	result, _ := preprocessAutoTables(content, sources)
+	result, _ := preprocessAutoTables(content, sources, "")
 	resultStr := string(result)
 
 	// Frontmatter should be preserved

--- a/internal/source/schema.go
+++ b/internal/source/schema.go
@@ -1,0 +1,89 @@
+package source
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+// QuerySQLiteSchema opens a SQLite database and returns column info for the
+// given table. This is a standalone function for use at parse time, before
+// a full SQLiteSource is created.
+//
+// Returns nil (no error) if the table doesn't exist or the DB can't be opened.
+// This allows graceful degradation — auto-tables will use text inputs as fallback.
+func QuerySQLiteSchema(dbPath, table, siteDir string) []ColumnInfo {
+	if dbPath == "" || table == "" {
+		return nil
+	}
+
+	if !isValidIdentifier(table) {
+		return nil
+	}
+
+	// Resolve relative path
+	if !filepath.IsAbs(dbPath) {
+		dbPath = filepath.Join(siteDir, dbPath)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
+
+	// Check table exists
+	var name string
+	err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&name)
+	if err != nil {
+		return nil
+	}
+
+	// Query PRAGMA table_info
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var columns []ColumnInfo
+	for rows.Next() {
+		var cid int
+		var colName, typeName string
+		var notNull, pk int
+		var dfltValue interface{}
+		if err := rows.Scan(&cid, &colName, &typeName, &notNull, &dfltValue, &pk); err != nil {
+			continue
+		}
+		// Skip internal columns
+		if colName == "id" || colName == "created_at" {
+			continue
+		}
+		columns = append(columns, ColumnInfo{
+			Name:     colName,
+			Type:     normalizeSQLiteType(typeName),
+			Required: notNull == 1,
+		})
+	}
+
+	return columns
+}
+
+// InputTypeForColumn returns the HTML input type for a given column type.
+func InputTypeForColumn(colType string) string {
+	switch strings.ToLower(colType) {
+	case "integer", "real":
+		return "number"
+	case "boolean":
+		return "checkbox"
+	case "date":
+		return "date"
+	case "datetime":
+		return "datetime-local"
+	default:
+		return "text"
+	}
+}

--- a/internal/source/schema_test.go
+++ b/internal/source/schema_test.go
@@ -1,0 +1,143 @@
+package source
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestQuerySQLiteSchema(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE items (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		price REAL NOT NULL,
+		done BOOLEAN DEFAULT 0,
+		due DATE,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	schema := QuerySQLiteSchema(dbPath, "items", dir)
+	if schema == nil {
+		t.Fatal("expected non-nil schema")
+	}
+
+	// Should exclude id and created_at
+	for _, col := range schema {
+		if col.Name == "id" || col.Name == "created_at" {
+			t.Errorf("internal column %q should be excluded", col.Name)
+		}
+	}
+
+	// Check types
+	typeMap := make(map[string]string)
+	for _, col := range schema {
+		typeMap[col.Name] = col.Type
+	}
+
+	if typeMap["name"] != "text" {
+		t.Errorf("expected name type 'text', got %q", typeMap["name"])
+	}
+	if typeMap["price"] != "real" {
+		t.Errorf("expected price type 'real', got %q", typeMap["price"])
+	}
+	if typeMap["done"] != "boolean" {
+		t.Errorf("expected done type 'boolean', got %q", typeMap["done"])
+	}
+	if typeMap["due"] != "date" {
+		t.Errorf("expected due type 'date', got %q", typeMap["due"])
+	}
+}
+
+func TestQuerySQLiteSchema_NonexistentTable(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	// Table doesn't exist — should return nil gracefully
+	schema := QuerySQLiteSchema(dbPath, "nonexistent", dir)
+	if schema != nil {
+		t.Errorf("expected nil for nonexistent table, got %v", schema)
+	}
+}
+
+func TestQuerySQLiteSchema_NonexistentDB(t *testing.T) {
+	// DB doesn't exist — should return nil gracefully
+	schema := QuerySQLiteSchema("/nonexistent/path.db", "items", "/nonexistent")
+	if schema != nil {
+		t.Errorf("expected nil for nonexistent DB, got %v", schema)
+	}
+}
+
+func TestQuerySQLiteSchema_Required(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE items (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		notes TEXT
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	schema := QuerySQLiteSchema(dbPath, "items", dir)
+
+	reqMap := make(map[string]bool)
+	for _, col := range schema {
+		reqMap[col.Name] = col.Required
+	}
+
+	if !reqMap["name"] {
+		t.Error("expected name to be required (NOT NULL)")
+	}
+	if reqMap["notes"] {
+		t.Error("expected notes to be optional (nullable)")
+	}
+}
+
+func TestInputTypeForColumn(t *testing.T) {
+	tests := []struct {
+		colType string
+		expect  string
+	}{
+		{"text", "text"},
+		{"integer", "number"},
+		{"real", "number"},
+		{"boolean", "checkbox"},
+		{"date", "date"},
+		{"datetime", "datetime-local"},
+		{"unknown", "text"},
+		{"", "text"},
+	}
+
+	for _, tt := range tests {
+		got := InputTypeForColumn(tt.colType)
+		if got != tt.expect {
+			t.Errorf("InputTypeForColumn(%q) = %q, want %q", tt.colType, got, tt.expect)
+		}
+	}
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -39,6 +39,22 @@ type WritableSource interface {
 	IsReadonly() bool
 }
 
+// ColumnInfo describes a column in a data source's schema.
+type ColumnInfo struct {
+	Name     string // Column name (e.g., "amount")
+	Type     string // Normalized type: "text", "integer", "real", "boolean", "date", "datetime"
+	Required bool   // Whether the column is NOT NULL
+}
+
+// SchemaProvider is an optional interface for sources that can expose their schema.
+// This is used by auto-tables to generate form inputs with appropriate types
+// (e.g., <input type="number"> for integer columns).
+type SchemaProvider interface {
+	// Schema returns column info for the source's data.
+	// Columns like "id" and "created_at" (internal) should be excluded.
+	Schema(ctx context.Context) ([]ColumnInfo, error)
+}
+
 // SQLExecutor extends Source with ability to execute arbitrary SQL statements.
 // This is used by custom actions defined in frontmatter (action kind: "sql").
 type SQLExecutor interface {

--- a/internal/source/sqlite.go
+++ b/internal/source/sqlite.go
@@ -379,6 +379,65 @@ func (s *SQLiteSource) discoverSchema() {
 	s.hasSchema = true
 }
 
+// Schema returns column information for the table, implementing SchemaProvider.
+// Excludes internal columns (id, created_at).
+func (s *SQLiteSource) Schema(ctx context.Context) ([]ColumnInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if !s.hasSchema {
+		return nil, nil
+	}
+
+	colQuery := fmt.Sprintf("PRAGMA table_info(%s)", s.table)
+	rows, err := s.db.QueryContext(ctx, colQuery)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite source %q: schema query failed: %w", s.name, err)
+	}
+	defer rows.Close()
+
+	var columns []ColumnInfo
+	for rows.Next() {
+		var cid int
+		var name, typeName string
+		var notNull, pk int
+		var dfltValue interface{}
+		if err := rows.Scan(&cid, &name, &typeName, &notNull, &dfltValue, &pk); err != nil {
+			continue
+		}
+		// Skip internal columns
+		if name == "id" || name == "created_at" {
+			continue
+		}
+		columns = append(columns, ColumnInfo{
+			Name:     name,
+			Type:     normalizeSQLiteType(typeName),
+			Required: notNull == 1,
+		})
+	}
+
+	return columns, nil
+}
+
+// normalizeSQLiteType converts SQLite type affinity to a normalized type string.
+func normalizeSQLiteType(sqlType string) string {
+	sqlType = strings.ToUpper(strings.TrimSpace(sqlType))
+	switch {
+	case strings.Contains(sqlType, "INT"):
+		return "integer"
+	case strings.Contains(sqlType, "REAL") || strings.Contains(sqlType, "FLOA") || strings.Contains(sqlType, "DOUB"):
+		return "real"
+	case strings.Contains(sqlType, "BOOL"):
+		return "boolean"
+	case strings.Contains(sqlType, "DATE") && !strings.Contains(sqlType, "DATETIME"):
+		return "date"
+	case strings.Contains(sqlType, "DATETIME") || strings.Contains(sqlType, "TIMESTAMP"):
+		return "datetime"
+	default:
+		return "text"
+	}
+}
+
 // Helper functions
 
 func isValidIdentifier(name string) bool {

--- a/page.go
+++ b/page.go
@@ -53,7 +53,7 @@ func ParseFile(path string) (*Page, error) {
 	// This requires a lightweight frontmatter pre-parse to get source configs.
 	if fmPre, _, fmErr := extractFrontmatter(processedContent); fmErr == nil && len(fmPre.Sources) > 0 {
 		var tableWarnings []string
-		processedContent, tableWarnings = preprocessAutoTables(processedContent, fmPre.Sources)
+		processedContent, tableWarnings = preprocessAutoTables(processedContent, fmPre.Sources, filepath.Dir(absPath))
 		for _, w := range tableWarnings {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 		}


### PR DESCRIPTION
## Summary

- Auto-tables now query SQLite `PRAGMA table_info` at parse time to generate forms with appropriate HTML input types
- `INTEGER`/`REAL` → `<input type="number">`, `BOOLEAN` → `checkbox`, `DATE` → `date`, `DATETIME` → `datetime-local`
- Non-SQLite sources gracefully fall back to `type="text"`
- New `SchemaProvider` interface for future runtime use by other source types

### Before (all text inputs):
```html
<input type="text" name="amount" ...>
<input type="text" name="done" ...>
```

### After (schema-aware inputs):
```html
<input type="number" name="amount" ...>
<input type="checkbox" name="done" ...>
```

## Test plan

- [x] `TestQuerySQLiteSchema` — verifies type mapping (text, real, boolean, date)
- [x] `TestQuerySQLiteSchema_NonexistentTable` / `_NonexistentDB` — graceful degradation
- [x] `TestQuerySQLiteSchema_Required` — NOT NULL detection
- [x] `TestInputTypeForColumn` — all type mappings
- [x] `TestGenerateWritableBlockWithSchema` — verifies correct input types in generated HTML
- [x] `TestGenerateWritableBlockWithoutSchema` — verifies text fallback
- [x] All existing auto-tables + internal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)