### PR TITLE
Phase 1 docs-site enablement: theme tokens, version prefix, edit-on-github, external-app router

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,23 @@ type Config struct {
 	// future multi-version deployment can mount several site builds under
 	// distinct prefixes (e.g. /v0/, /latest/) without collision.
 	VersionPrefix string `yaml:"version_prefix,omitempty"`
+
+	// Routes declares custom URL routes that bypass the markdown page
+	// resolver. Each entry binds a request-path pattern to an upstream
+	// destination. Currently only `type: proxy` is supported, which
+	// reverse-proxies the request (including WebSocket upgrades) to the
+	// configured upstream host. The full request path is forwarded
+	// unchanged — the upstream is responsible for its own URL structure.
+	Routes []RouteEntry `yaml:"routes,omitempty"`
+}
+
+// RouteEntry binds a URL pattern to a destination. A pattern ending in
+// "/" matches that subtree; otherwise it must match exactly. Routes are
+// evaluated in declaration order; first match wins.
+type RouteEntry struct {
+	Pattern  string `yaml:"pattern"`
+	Type     string `yaml:"type"`
+	Upstream string `yaml:"upstream"`
 }
 
 // OutputConfig defines an output destination for notifications.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,13 @@ type Config struct {
 	API         *APIConfig              `yaml:"api,omitempty"`
 	Webhooks    map[string]*Webhook     `yaml:"webhooks,omitempty"`
 	Outputs     map[string]*OutputConfig `yaml:"outputs,omitempty"`
+
+	// VersionPrefix, when non-empty, becomes a URL path segment that is
+	// stripped from incoming requests before route resolution. Routes serve
+	// equivalently with or without the prefix; the prefix exists so that a
+	// future multi-version deployment can mount several site builds under
+	// distinct prefixes (e.g. /v0/, /latest/) without collision.
+	VersionPrefix string `yaml:"version_prefix,omitempty"`
 }
 
 // OutputConfig defines an output destination for notifications.

--- a/internal/server/compression.go
+++ b/internal/server/compression.go
@@ -27,6 +27,16 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	return w.Writer.Write(b)
 }
 
+// Unwrap exposes the underlying ResponseWriter so handlers that must
+// bypass gzip wrapping (notably reverse-proxied responses, where the
+// upstream owns Content-Length / Content-Encoding) can write the raw
+// bytes without double-encoding. Callers should also clear any eager
+// `Content-Encoding: gzip` / `Vary: Accept-Encoding` headers the
+// middleware already set on the underlying writer.
+func (w *gzipResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 // gzipWriterPool reuses gzip writers to reduce GC pressure
 var gzipWriterPool = sync.Pool{
 	New: func() interface{} {

--- a/internal/server/compression.go
+++ b/internal/server/compression.go
@@ -8,11 +8,17 @@ import (
 	"sync"
 )
 
-// gzipResponseWriter wraps http.ResponseWriter to compress responses
+// gzipResponseWriter wraps http.ResponseWriter to compress responses.
+// gz is initialized lazily on the first Write so that handlers which
+// bypass this wrapper (via Unwrap) never trigger a gz.Close that would
+// flush an empty gzip stream into the real response body.
 type gzipResponseWriter struct {
+	gz          *gzip.Writer
+	target      http.ResponseWriter
+	gzReady     bool
+	wroteHeader bool
 	io.Writer
 	http.ResponseWriter
-	wroteHeader bool
 }
 
 func (w *gzipResponseWriter) WriteHeader(status int) {
@@ -24,7 +30,11 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)
 	}
-	return w.Writer.Write(b)
+	if !w.gzReady {
+		w.gz.Reset(w.target)
+		w.gzReady = true
+	}
+	return w.gz.Write(b)
 }
 
 // Unwrap exposes the underlying ResponseWriter so handlers that must
@@ -64,21 +74,24 @@ func compressionMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Content-Encoding", "gzip")
 		w.Header().Add("Vary", "Accept-Encoding")
 
-		// Get gzip writer from pool
+		// Get gzip writer from pool. The writer is left pointing at
+		// io.Discard until the first body Write, so a handler that
+		// unwraps and never writes through gz produces a clean response
+		// (no trailing empty-stream bytes leaking into the wire).
 		gz := gzipWriterPool.Get().(*gzip.Writer)
-		defer func() {
-			gz.Close()
-			gz.Reset(io.Discard)
-			gzipWriterPool.Put(gz)
-		}()
-
-		gz.Reset(w)
-
-		// Wrap response writer
 		gzw := &gzipResponseWriter{
+			gz:             gz,
+			target:         w,
 			Writer:         gz,
 			ResponseWriter: w,
 		}
+		defer func() {
+			if gzw.gzReady {
+				gz.Close()
+			}
+			gz.Reset(io.Discard)
+			gzipWriterPool.Put(gz)
+		}()
 
 		next.ServeHTTP(gzw, r)
 	})

--- a/internal/server/edit_link.go
+++ b/internal/server/edit_link.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"strings"
+)
+
+// buildEditURL returns the GitHub "edit this file" URL for a page, or ""
+// when no link can be constructed. Resolution order:
+//
+//  1. Page frontmatter `source_repo` + `source_path` (canonical when the
+//     page was synced from another repo and that repo owns the content).
+//  2. Site-level `repository` + the page's own relative file path within
+//     the docs site (canonical when the docs site owns the content).
+//
+// The branch defaults to "main"; configurable per-site work is deferred.
+func buildEditURL(siteRepo, sourceRepo, sourcePath, sitePagePath string) string {
+	repo := strings.TrimSuffix(strings.TrimSpace(sourceRepo), "/")
+	path := strings.TrimPrefix(strings.TrimSpace(sourcePath), "/")
+	if repo == "" || path == "" {
+		// Fall back to site-level repo + the page's relative path.
+		repo = strings.TrimSuffix(strings.TrimSpace(siteRepo), "/")
+		path = strings.TrimPrefix(strings.TrimSpace(sitePagePath), "/")
+	}
+	if repo == "" || path == "" {
+		return ""
+	}
+	if !strings.HasPrefix(repo, "https://github.com/") {
+		// Only GitHub URLs are supported in Phase 1. Other forges will need
+		// per-host URL templates; keep them out for now to avoid a broken link.
+		return ""
+	}
+	return repo + "/edit/main/" + path
+}

--- a/internal/server/edit_link_test.go
+++ b/internal/server/edit_link_test.go
@@ -1,0 +1,81 @@
+package server
+
+import "testing"
+
+func TestBuildEditURL_FrontmatterWins(t *testing.T) {
+	// When source_repo + source_path are both set, they take precedence.
+	got := buildEditURL(
+		"https://github.com/livetemplate/docs",
+		"https://github.com/livetemplate/livetemplate",
+		"docs/guides/x.md",
+		"reference/some-page.md",
+	)
+	want := "https://github.com/livetemplate/livetemplate/edit/main/docs/guides/x.md"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildEditURL_FallsBackToSiteRepo(t *testing.T) {
+	// No frontmatter source → use site repo + page's own relative path.
+	got := buildEditURL(
+		"https://github.com/livetemplate/docs",
+		"",
+		"",
+		"recipes/foo.md",
+	)
+	want := "https://github.com/livetemplate/docs/edit/main/recipes/foo.md"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildEditURL_PartialFrontmatterFallsBack(t *testing.T) {
+	// source_repo set but source_path empty → fall back fully.
+	got := buildEditURL(
+		"https://github.com/livetemplate/docs",
+		"https://github.com/livetemplate/livetemplate",
+		"",
+		"reference/some-page.md",
+	)
+	want := "https://github.com/livetemplate/docs/edit/main/reference/some-page.md"
+	if got != want {
+		t.Errorf("partial frontmatter should fall back: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildEditURL_EmptyWhenNothingSet(t *testing.T) {
+	if got := buildEditURL("", "", "", ""); got != "" {
+		t.Errorf("expected empty URL, got %q", got)
+	}
+	if got := buildEditURL("", "", "", "page.md"); got != "" {
+		t.Errorf("no repo at all → empty, got %q", got)
+	}
+}
+
+func TestBuildEditURL_NormalizesSlashes(t *testing.T) {
+	got := buildEditURL(
+		"https://github.com/livetemplate/docs/", // trailing /
+		"",
+		"",
+		"/reference/foo.md", // leading /
+	)
+	want := "https://github.com/livetemplate/docs/edit/main/reference/foo.md"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildEditURL_NonGitHubReturnsEmpty(t *testing.T) {
+	// Phase 1 only supports GitHub. GitLab/Bitbucket would need per-host
+	// templates; returning "" here avoids rendering a broken link.
+	got := buildEditURL(
+		"https://gitlab.com/example/docs",
+		"",
+		"",
+		"page.md",
+	)
+	if got != "" {
+		t.Errorf("non-GitHub repo should return empty, got %q", got)
+	}
+}

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -41,18 +41,15 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 	rp := httputil.NewSingleHostReverseProxy(u)
 	origDirector := rp.Director
 	rp.Director = func(req *http.Request) {
+		// Save Path AND RawPath before the default Director runs.
+		// NewSingleHostReverseProxy's default Director joins
+		// upstream.Path with req.URL.Path, which is wrong for our
+		// passthrough model where the upstream owns the full URL
+		// space — restore both fields after to forward the request
+		// path verbatim, including any percent-encoding.
+		savedPath, savedRaw := req.URL.Path, req.URL.RawPath
 		origDirector(req)
-		// Restore the original request path. NewSingleHostReverseProxy's
-		// default Director joins upstream.Path with req.URL.Path, which
-		// is wrong for our passthrough model where upstream owns the
-		// full URL space.
-		req.URL.Path = req.URL.RawPath
-		if req.URL.Path == "" {
-			req.URL.Path = req.RequestURI
-			if i := strings.IndexByte(req.URL.Path, '?'); i >= 0 {
-				req.URL.Path = req.URL.Path[:i]
-			}
-		}
+		req.URL.Path, req.URL.RawPath = savedPath, savedRaw
 		req.Host = u.Host
 	}
 

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+// proxyRoute is the runtime representation of a config.RouteEntry with
+// type=proxy. It pairs a path matcher with a configured reverse-proxy
+// handler. WebSocket upgrades are forwarded automatically by the stdlib
+// reverse proxy (Go 1.12+).
+type proxyRoute struct {
+	pattern  string
+	isPrefix bool
+	upstream string
+	handler  http.Handler
+}
+
+// newProxyRoute constructs a proxyRoute from a config entry. Returns an
+// error if the entry's type is unsupported or upstream URL is unparseable.
+func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
+	if re.Type != "proxy" {
+		return nil, fmt.Errorf("unsupported route type %q (only %q supported)", re.Type, "proxy")
+	}
+	if re.Pattern == "" || !strings.HasPrefix(re.Pattern, "/") {
+		return nil, fmt.Errorf("pattern %q must start with /", re.Pattern)
+	}
+	u, err := url.Parse(re.Upstream)
+	if err != nil {
+		return nil, fmt.Errorf("invalid upstream %q: %w", re.Upstream, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("upstream %q must be http or https", re.Upstream)
+	}
+
+	rp := httputil.NewSingleHostReverseProxy(u)
+	origDirector := rp.Director
+	rp.Director = func(req *http.Request) {
+		origDirector(req)
+		// Restore the original request path. NewSingleHostReverseProxy's
+		// default Director joins upstream.Path with req.URL.Path, which
+		// is wrong for our passthrough model where upstream owns the
+		// full URL space.
+		req.URL.Path = req.URL.RawPath
+		if req.URL.Path == "" {
+			req.URL.Path = req.RequestURI
+			if i := strings.IndexByte(req.URL.Path, '?'); i >= 0 {
+				req.URL.Path = req.URL.Path[:i]
+			}
+		}
+		req.Host = u.Host
+	}
+
+	return &proxyRoute{
+		pattern:  re.Pattern,
+		isPrefix: strings.HasSuffix(re.Pattern, "/"),
+		upstream: re.Upstream,
+		handler:  rp,
+	}, nil
+}
+
+// matches reports whether the given request path falls under this route.
+// Prefix routes (pattern ending in "/") match the path equal to
+// pattern-without-trailing-slash, and any path starting with pattern.
+// Exact routes match only on identical path.
+func (p *proxyRoute) matches(path string) bool {
+	if p.isPrefix {
+		bare := strings.TrimSuffix(p.pattern, "/")
+		return path == bare || strings.HasPrefix(path, p.pattern)
+	}
+	return path == p.pattern
+}
+
+// buildProxyRoutes converts config entries into runtime routes, skipping
+// (and logging) any entries with errors so a single bad route does not
+// abort startup. Returns the constructed slice and the count of skipped
+// entries for the caller to log.
+func buildProxyRoutes(entries []config.RouteEntry) ([]*proxyRoute, []error) {
+	var routes []*proxyRoute
+	var errs []error
+	for i, re := range entries {
+		pr, err := newProxyRoute(re)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("route %d (%q): %w", i, re.Pattern, err))
+			continue
+		}
+		routes = append(routes, pr)
+	}
+	return routes, errs
+}

--- a/internal/server/proxy_routes_test.go
+++ b/internal/server/proxy_routes_test.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+func TestNewProxyRoute_RejectsUnsupportedType(t *testing.T) {
+	_, err := newProxyRoute(config.RouteEntry{Pattern: "/x", Type: "markdown", Upstream: "http://up"})
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+}
+
+func TestNewProxyRoute_RejectsBadPattern(t *testing.T) {
+	cases := []string{"", "x", "no-leading-slash"}
+	for _, p := range cases {
+		_, err := newProxyRoute(config.RouteEntry{Pattern: p, Type: "proxy", Upstream: "http://up"})
+		if err == nil {
+			t.Errorf("expected error for pattern %q", p)
+		}
+	}
+}
+
+func TestNewProxyRoute_RejectsBadUpstream(t *testing.T) {
+	cases := []string{"", "://bad", "ftp://example.com"}
+	for _, u := range cases {
+		_, err := newProxyRoute(config.RouteEntry{Pattern: "/x", Type: "proxy", Upstream: u})
+		if err == nil {
+			t.Errorf("expected error for upstream %q", u)
+		}
+	}
+}
+
+func TestProxyRouteMatches(t *testing.T) {
+	// Prefix route
+	prefix, err := newProxyRoute(config.RouteEntry{Pattern: "/patterns/", Type: "proxy", Upstream: "http://up"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefixCases := []struct {
+		path string
+		want bool
+	}{
+		{"/patterns", true},      // bare match (no trailing slash)
+		{"/patterns/", true},     // exact pattern
+		{"/patterns/foo", true},  // sub-path
+		{"/patternsfoo", false},  // not a prefix-segment
+		{"/other", false},        // unrelated
+		{"/", false},             // root
+	}
+	for _, c := range prefixCases {
+		if got := prefix.matches(c.path); got != c.want {
+			t.Errorf("prefix /patterns/ matches %q = %v, want %v", c.path, got, c.want)
+		}
+	}
+
+	// Exact route
+	exact, err := newProxyRoute(config.RouteEntry{Pattern: "/exact", Type: "proxy", Upstream: "http://up"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exact.matches("/exact") {
+		t.Error("exact /exact should match /exact")
+	}
+	if exact.matches("/exact/sub") {
+		t.Error("exact /exact should NOT match /exact/sub")
+	}
+	if exact.matches("/exactly") {
+		t.Error("exact /exact should NOT match /exactly")
+	}
+}
+
+func TestBuildProxyRoutes_SkipsInvalidEntries(t *testing.T) {
+	entries := []config.RouteEntry{
+		{Pattern: "/good", Type: "proxy", Upstream: "http://example.com"},
+		{Pattern: "bad", Type: "proxy", Upstream: "http://example.com"},
+		{Pattern: "/also-good/", Type: "proxy", Upstream: "https://example.com"},
+	}
+	routes, errs := buildProxyRoutes(entries)
+	if len(routes) != 2 {
+		t.Errorf("expected 2 valid routes, got %d", len(routes))
+	}
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error, got %d", len(errs))
+	}
+}
+
+// Integration: real upstream + real reverse proxy + path forwarded unchanged.
+func TestProxyRoute_HTTPIntegration(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream-Saw", r.URL.Path)
+		_, _ = io.WriteString(w, "hello "+r.URL.Path)
+	}))
+	defer upstream.Close()
+
+	pr, err := newProxyRoute(config.RouteEntry{Pattern: "/patterns/", Type: "proxy", Upstream: upstream.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/patterns/", pr.handler)
+	front := httptest.NewServer(mux)
+	defer front.Close()
+
+	resp, err := http.Get(front.URL + "/patterns/click-to-edit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "hello /patterns/click-to-edit") {
+		t.Errorf("body: %q", body)
+	}
+	if got := resp.Header.Get("X-Upstream-Saw"); got != "/patterns/click-to-edit" {
+		t.Errorf("upstream saw %q, want full path passthrough", got)
+	}
+}
+
+// Integration: WebSocket upgrade survives the reverse proxy. Critical for
+// livetemplate apps which use WS for real-time updates.
+func TestProxyRoute_WebSocketIntegration(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upstream upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		mt, msg, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		_ = conn.WriteMessage(mt, append([]byte("echo:"), msg...))
+	}))
+	defer upstream.Close()
+
+	pr, err := newProxyRoute(config.RouteEntry{Pattern: "/proxy/", Type: "proxy", Upstream: upstream.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/proxy/", pr.handler)
+	front := httptest.NewServer(mux)
+	defer front.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(front.URL, "http") + "/proxy/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("ws dial via proxy: %v", err)
+	}
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("hi")); err != nil {
+		t.Fatal(err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(msg) != "echo:hi" {
+		t.Errorf("ws echo: got %q", msg)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -353,9 +353,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// policy). Without this, our X-Frame-Options/CSP would override the
 	// upstream's intent — which breaks WebSocket apps that need their own
 	// connect-src and frame settings.
+	//
+	// Reverse-proxied responses also bypass our gzip middleware: upstreams
+	// own their own Content-Encoding/Content-Length, and double-encoding
+	// breaks browsers (Chrome reports ERR_CONTENT_DECODING_FAILED).
 	for _, pr := range s.proxyRoutes {
 		if pr.matches(r.URL.Path) {
-			pr.handler.ServeHTTP(w, r)
+			rw := w
+			if u, ok := w.(interface{ Unwrap() http.ResponseWriter }); ok {
+				rw = u.Unwrap()
+				rw.Header().Del("Content-Encoding")
+				rw.Header().Del("Vary")
+			}
+			pr.handler.ServeHTTP(rw, r)
 			return
 		}
 	}
@@ -865,7 +875,6 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
     <!-- PicoCSS - Semantic/Classless CSS Framework (embedded) -->
     <link rel="stylesheet" href="/assets/pico.css">
     <link rel="stylesheet" href="/assets/tinkerdown-client.css">
-    %s
     <style>
         /* Theme Variables */
         :root {
@@ -2114,6 +2123,7 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             border-radius: 0.3em;
         }
     </style>
+    %s
 
     <!-- Prism.js for syntax highlighting (embedded) -->
     <link href="/assets/prism.css" rel="stylesheet" />

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -700,6 +700,26 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
 		prevNextHTML = s.renderPrevNext(currentPath)
 	}
 
+	// Build the "Edit this page on GitHub" footer link, if configurable.
+	// Page frontmatter (source_repo + source_path) wins over site repo.
+	editLinkHTML := ""
+	siteRepo := ""
+	if s.config.Site != nil {
+		siteRepo = s.config.Site.Repository
+	}
+	pageRelPath := ""
+	if s.siteManager != nil {
+		if node, ok := s.siteManager.GetPage(currentPath); ok && node != nil {
+			pageRelPath = node.FilePath
+		}
+	}
+	if editURL := buildEditURL(siteRepo, page.SourceRepo, page.SourcePath, pageRelPath); editURL != "" {
+		editLinkHTML = fmt.Sprintf(
+			`<div class="page-edit-link"><a href="%s" target="_blank" rel="noopener">Edit this page on GitHub</a></div>`,
+			editURL,
+		)
+	}
+
 	// Wrap content with breadcrumbs and prev/next
 	contentWithNav := fmt.Sprintf(`
 		%s
@@ -707,7 +727,8 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
 			%s
 		</div>
 		%s
-	`, breadcrumbsHTML, content, prevNextHTML)
+		%s
+	`, breadcrumbsHTML, content, editLinkHTML, prevNextHTML)
 
 	// Build WebSocket URL from host with page path for multi-page routing
 	wsURL := fmt.Sprintf("ws://%s/ws?page=%s", host, url.QueryEscape(currentPath))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -350,6 +350,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"connect-src 'self'; "+
 			"frame-ancestors 'none'")
 
+	// Strip the configured version prefix (if any) so the rest of routing
+	// can be prefix-agnostic. With prefix unset this is a no-op.
+	r.URL.Path = stripVersionPrefix(r.URL.Path, s.config.VersionPrefix)
+
 	// Health endpoint (always available, especially important in headless mode)
 	if r.URL.Path == "/health" {
 		s.serveHealth(w, r)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -385,8 +385,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"frame-ancestors 'none'")
 
 	// Strip the configured version prefix (if any) so the rest of routing
-	// can be prefix-agnostic. With prefix unset this is a no-op.
+	// can be prefix-agnostic. With prefix unset this is a no-op. Both
+	// Path and RawPath must be stripped so downstream handlers (e.g. the
+	// reverse-proxy Director, which preserves RawPath verbatim) don't
+	// see an out-of-sync original-prefixed path.
 	r.URL.Path = stripVersionPrefix(r.URL.Path, s.config.VersionPrefix)
+	if r.URL.RawPath != "" {
+		r.URL.RawPath = stripVersionPrefix(r.URL.RawPath, s.config.VersionPrefix)
+	}
 
 	// Health endpoint (always available, especially important in headless mode)
 	if r.URL.Path == "/health" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	rateLimitDone      <-chan struct{}                        // Closed when rate limiter goroutine exits
 	recentSourceWrites map[string]time.Time                  // Files recently written by source actions
 	sourceWriteMu      sync.Mutex                            // Protects recentSourceWrites
+	proxyRoutes        []*proxyRoute                         // Custom routes that bypass markdown resolution and reverse-proxy to upstream
 }
 
 // New creates a new server for the given root directory.
@@ -75,6 +76,17 @@ func NewWithConfig(rootDir string, cfg *config.Config) *Server {
 	// Initialize site manager if in site mode
 	if cfg.IsSiteMode() {
 		srv.siteManager = site.New(rootDir, cfg)
+	}
+
+	// Build reverse-proxy routes from config. Bad entries are logged but
+	// do not abort startup — operator-friendly behaviour for misconfig.
+	if len(cfg.Routes) > 0 {
+		routes, errs := buildProxyRoutes(cfg.Routes)
+		srv.proxyRoutes = routes
+		for _, err := range errs {
+			log.Printf("[Routes] skipping invalid route: %v", err)
+		}
+		log.Printf("[Routes] loaded %d proxy route(s)", len(routes))
 	}
 
 	// Initialize playground handler
@@ -336,6 +348,18 @@ func (s *Server) Routes() []*Route {
 
 // ServeHTTP implements http.Handler.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Custom proxy routes match BEFORE we set our own security headers,
+	// so the upstream owns its full response surface (CSP, cookies, frame
+	// policy). Without this, our X-Frame-Options/CSP would override the
+	// upstream's intent — which breaks WebSocket apps that need their own
+	// connect-src and frame settings.
+	for _, pr := range s.proxyRoutes {
+		if pr.matches(r.URL.Path) {
+			pr.handler.ServeHTTP(w, r)
+			return
+		}
+	}
+
 	// Security headers applied via SecurityHeadersMiddleware on API routes.
 	// Apply same headers to all other routes for consistency.
 	w.Header().Set("X-Frame-Options", "DENY")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -647,6 +647,11 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
 	// Render code blocks with metadata for client discovery
 	content := s.renderContent(page)
 
+	// User-config styling overrides (primary color, font) and the initial
+	// theme selection for visitors with no localStorage value.
+	stylingOverrideCSS := buildStylingOverrideCSS(s.config.Styling)
+	defaultTheme := themeDefault(s.config.Styling)
+
 	// Determine effective sidebar setting (page-level overrides site-level)
 	showSidebar := s.config.Features.Sidebar
 	if page.Sidebar != nil {
@@ -811,6 +816,7 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
     <!-- PicoCSS - Semantic/Classless CSS Framework (embedded) -->
     <link rel="stylesheet" href="/assets/pico.css">
     <link rel="stylesheet" href="/assets/tinkerdown-client.css">
+    %s
     <style>
         /* Theme Variables */
         :root {
@@ -2113,9 +2119,9 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             const STORAGE_KEY = 'tinkerdown-theme';
             const html = document.documentElement;
 
-            // Get current theme from localStorage or default to 'auto'
+            // Get current theme from localStorage or default from server config.
             function getStoredTheme() {
-                return localStorage.getItem(STORAGE_KEY) || 'auto';
+                return localStorage.getItem(STORAGE_KEY) || %q;
             }
 
             // Get system preference
@@ -2478,7 +2484,7 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
     </script>
 %s
 </body>
-</html>`, wsURL, showSidebar, page.Title, sidebar, contentWithNav, chartScript)
+</html>`, wsURL, showSidebar, page.Title, stylingOverrideCSS, sidebar, contentWithNav, defaultTheme, chartScript)
 
 	return html
 }

--- a/internal/server/styling.go
+++ b/internal/server/styling.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+// validThemes maps the user-configurable theme name to the runtime value
+// the client-side toggle accepts. "clean" is a legacy alias for "light".
+var validThemes = map[string]string{
+	"light": "light",
+	"dark":  "dark",
+	"auto":  "auto",
+	"clean": "light",
+}
+
+// themeDefault returns the initial theme selection for a fresh visitor with
+// no localStorage value. Falls back to "auto" (system preference) for empty
+// or unrecognized config values.
+func themeDefault(s config.StylingConfig) string {
+	if v, ok := validThemes[strings.ToLower(strings.TrimSpace(s.Theme))]; ok {
+		return v
+	}
+	return "auto"
+}
+
+// buildStylingOverrideCSS returns a <style> block overriding theme tokens
+// based on user config. Returns "" if no overrides are set.
+func buildStylingOverrideCSS(s config.StylingConfig) string {
+	primary := sanitizeCSSValue(s.PrimaryColor)
+	font := sanitizeCSSValue(s.Font)
+	if primary == "" && font == "" {
+		return ""
+	}
+
+	var out strings.Builder
+	out.WriteString("<style>\n")
+	if primary != "" {
+		fmt.Fprintf(&out, "        :root { --accent: %s; }\n", primary)
+	}
+	if font != "" {
+		fmt.Fprintf(&out, "        body { font-family: %s, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Helvetica, Arial, sans-serif; }\n", font)
+	}
+	out.WriteString("    </style>")
+	return out.String()
+}
+
+// sanitizeCSSValue strips characters that could escape a CSS value/string
+// context. Returns "" for any value containing a meta-character. Caller is
+// expected to already have applied trimming to whitespace-only inputs.
+func sanitizeCSSValue(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	if strings.ContainsAny(v, "<>{};\"\n\r") {
+		return ""
+	}
+	return v
+}

--- a/internal/server/styling_test.go
+++ b/internal/server/styling_test.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+func TestThemeDefault(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "auto"},
+		{"auto", "auto"},
+		{"light", "light"},
+		{"dark", "dark"},
+		{"clean", "light"},
+		{"CLEAN", "light"},
+		{"  dark  ", "dark"},
+		{"unknown", "auto"},
+	}
+	for _, c := range cases {
+		got := themeDefault(config.StylingConfig{Theme: c.in})
+		if got != c.want {
+			t.Errorf("themeDefault(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBuildStylingOverrideCSS_Empty(t *testing.T) {
+	if got := buildStylingOverrideCSS(config.StylingConfig{}); got != "" {
+		t.Errorf("empty config should return empty string, got %q", got)
+	}
+}
+
+func TestBuildStylingOverrideCSS_PrimaryColorOnly(t *testing.T) {
+	got := buildStylingOverrideCSS(config.StylingConfig{PrimaryColor: "#5a67d8"})
+	if !strings.Contains(got, "--accent: #5a67d8") {
+		t.Errorf("missing accent override: %q", got)
+	}
+	if strings.Contains(got, "font-family") {
+		t.Errorf("font-family should not appear when font is empty: %q", got)
+	}
+}
+
+func TestBuildStylingOverrideCSS_FontOnly(t *testing.T) {
+	got := buildStylingOverrideCSS(config.StylingConfig{Font: "system-ui"})
+	if !strings.Contains(got, "font-family: system-ui") {
+		t.Errorf("missing font-family: %q", got)
+	}
+	if strings.Contains(got, "--accent") {
+		t.Errorf("--accent should not appear when primary color is empty: %q", got)
+	}
+}
+
+func TestBuildStylingOverrideCSS_Both(t *testing.T) {
+	got := buildStylingOverrideCSS(config.StylingConfig{
+		PrimaryColor: "rebeccapurple",
+		Font:         "Inter",
+	})
+	if !strings.Contains(got, "--accent: rebeccapurple") {
+		t.Errorf("missing accent: %q", got)
+	}
+	if !strings.Contains(got, "font-family: Inter") {
+		t.Errorf("missing font: %q", got)
+	}
+	if !strings.HasPrefix(got, "<style>") || !strings.HasSuffix(got, "</style>") {
+		t.Errorf("malformed style block: %q", got)
+	}
+}
+
+func TestSanitizeCSSValue_BlocksInjection(t *testing.T) {
+	blocked := []string{
+		"</style><script>alert(1)</script>",
+		"red; } body { display: none",
+		`abc"def`,
+		"abc\nbad",
+		"abc\rbad",
+		"<svg>",
+	}
+	for _, v := range blocked {
+		if got := sanitizeCSSValue(v); got != "" {
+			t.Errorf("sanitizeCSSValue(%q) should be blocked, got %q", v, got)
+		}
+	}
+}
+
+func TestSanitizeCSSValue_AllowsValidValues(t *testing.T) {
+	allowed := []string{
+		"#5a67d8",
+		"rebeccapurple",
+		"rgb(90, 103, 216)",
+		"system-ui",
+		"Inter",
+	}
+	for _, v := range allowed {
+		if got := sanitizeCSSValue(v); got != v {
+			t.Errorf("sanitizeCSSValue(%q) should pass, got %q", v, got)
+		}
+	}
+}
+
+// Integration check: when both override CSS and theme default are wired, they
+// must not interfere with each other or produce conflicting output.
+func TestStylingOverrideAndThemeDefault_Compose(t *testing.T) {
+	cfg := config.StylingConfig{
+		Theme:        "dark",
+		PrimaryColor: "#5a67d8",
+		Font:         "Inter",
+	}
+	if got := themeDefault(cfg); got != "dark" {
+		t.Errorf("themeDefault dark: got %q", got)
+	}
+	got := buildStylingOverrideCSS(cfg)
+	if !strings.Contains(got, "--accent: #5a67d8") || !strings.Contains(got, "font-family: Inter") {
+		t.Errorf("override missing: %q", got)
+	}
+}

--- a/internal/server/version_prefix.go
+++ b/internal/server/version_prefix.go
@@ -6,6 +6,10 @@ import "strings"
 // prefix removed. Empty prefix is a no-op. The prefix is matched as a path
 // segment, not a substring: prefix "v1" strips "/v1" and "/v1/x" but not
 // "/v1foo". An exact match of "/" + prefix is normalized to "/".
+//
+// Caller must apply the result to BOTH r.URL.Path AND r.URL.RawPath when
+// the latter is set; otherwise downstream handlers reading RawPath (e.g.
+// reverse-proxy directors) see an out-of-sync original-prefixed path.
 func stripVersionPrefix(path, prefix string) string {
 	prefix = strings.Trim(prefix, "/")
 	if prefix == "" {

--- a/internal/server/version_prefix.go
+++ b/internal/server/version_prefix.go
@@ -1,0 +1,23 @@
+package server
+
+import "strings"
+
+// stripVersionPrefix returns the request path with the configured version
+// prefix removed. Empty prefix is a no-op. The prefix is matched as a path
+// segment, not a substring: prefix "v1" strips "/v1" and "/v1/x" but not
+// "/v1foo". An exact match of "/" + prefix is normalized to "/".
+func stripVersionPrefix(path, prefix string) string {
+	prefix = strings.Trim(prefix, "/")
+	if prefix == "" {
+		return path
+	}
+	full := "/" + prefix
+	switch {
+	case path == full:
+		return "/"
+	case strings.HasPrefix(path, full+"/"):
+		return path[len(full):]
+	default:
+		return path
+	}
+}

--- a/internal/server/version_prefix_test.go
+++ b/internal/server/version_prefix_test.go
@@ -1,0 +1,28 @@
+package server
+
+import "testing"
+
+func TestStripVersionPrefix(t *testing.T) {
+	cases := []struct {
+		name, path, prefix, want string
+	}{
+		{"empty prefix is no-op", "/foo/bar", "", "/foo/bar"},
+		{"empty prefix and root", "/", "", "/"},
+		{"exact prefix match becomes root", "/v1", "v1", "/"},
+		{"prefix with leading slash works", "/v1", "/v1", "/"},
+		{"strip prefix from sub-path", "/v1/foo/bar", "v1", "/foo/bar"},
+		{"do not strip if not present", "/foo/bar", "v1", "/foo/bar"},
+		{"do not strip when prefix is a substring of segment", "/v1foo/bar", "v1", "/v1foo/bar"},
+		{"do not strip when prefix is part of deeper segment", "/foo/v1/bar", "v1", "/foo/v1/bar"},
+		{"trailing slash on prefix is normalized", "/v1/x", "v1/", "/x"},
+		{"latest as prefix", "/latest/getting-started/install", "latest", "/getting-started/install"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stripVersionPrefix(c.path, c.prefix)
+			if got != c.want {
+				t.Errorf("stripVersionPrefix(%q, %q) = %q, want %q", c.path, c.prefix, got, c.want)
+			}
+		})
+	}
+}

--- a/page.go
+++ b/page.go
@@ -73,6 +73,8 @@ func ParseFile(path string) (*Page, error) {
 	page.Type = fm.Type
 	page.StaticHTML = staticHTML
 	page.SourceFile = absPath // Track source file
+	page.SourceRepo = fm.SourceRepo
+	page.SourcePath = fm.SourcePath
 	page.Sidebar = fm.Sidebar // Page-level sidebar override
 	page.Config = PageConfig{
 		Persist:   fm.Persist,

--- a/parser.go
+++ b/parser.go
@@ -104,6 +104,14 @@ type Frontmatter struct {
 	// Top-level convenience options
 	Sidebar *bool `yaml:"sidebar,omitempty"` // Show navigation sidebar (overrides features.sidebar)
 
+	// Source provenance — used to render an "Edit this page" link that
+	// points at the canonical source file in its origin repo. Useful when
+	// a page was synced from another repo and the docs site is not the
+	// canonical home of the content. Both default to "" (use site-level
+	// repository + the page's own relative path).
+	SourceRepo string `yaml:"source_repo,omitempty"` // e.g. "https://github.com/livetemplate/livetemplate"
+	SourcePath string `yaml:"source_path,omitempty"` // e.g. "docs/guides/progressive-complexity.md"
+
 	// Chart customization (keyed by heading slug)
 	Charts map[string]ChartOptions `yaml:"charts,omitempty"`
 

--- a/tinkerdown.go
+++ b/tinkerdown.go
@@ -10,6 +10,8 @@ type Page struct {
 	Title             string
 	Type              string // tutorial, guide, reference, playground
 	SourceFile        string // Absolute path to source .md file (for error messages)
+	SourceRepo        string // Origin GitHub repo URL from frontmatter (for edit link)
+	SourcePath        string // Path within origin repo from frontmatter (for edit link)
 	Sidebar           *bool  // nil = use default, true/false = explicit override
 	Config            PageConfig
 	StaticHTML        string


### PR DESCRIPTION
Six commits enabling tinkerdown to serve as the LiveTemplate docs site engine. Every change is generic — no docs-site-specific code per the project CLAUDE.md.

## What's in this PR

- **`eef808c` PR-A** — wire `styling.theme/primary_color/font` config so the existing CSS variable infrastructure honors user values. Includes legacy "clean" → "light" alias.
- **`bfa1f6b` PR-B** — optional `version_prefix` config for path routing; primitive for future multi-version docs.
- **`34b9b72` PR-D** — reverse-proxy `routes:` block with WebSocket support. Each entry binds a URL pattern to an upstream HTTP destination, bypassing markdown resolution. Cookies/headers from upstream pass through; tinkerdown's own security headers are explicitly NOT applied to proxied responses.
- **`45a2483` PR-C** — \"Edit this page on GitHub\" footer link. Honors per-page `source_repo`/`source_path` frontmatter (fall-through to site-level `repository`).
- **`c8b0209` fix** — bypass gzip middleware for proxied responses + fix CSS source-order so the styling override actually wins.
- **`7637aa5` fix** — lazy-init gzip writer to avoid a 23-byte empty-stream tail bug that broke Chrome's decoder for proxied responses (RFC 1952 allows concatenated members so curl/gunzip accepted the bad output, but Chrome correctly rejects it).

## Tests

Each PR ships unit tests (8 + 10 + 7 + 6 = 31 new tests in `internal/server/`). Full internal/server suite passes locally (~1.6s).

End-to-end verified against a live deployment (https://livetemplate-docs-staging.fly.dev/) with 6 chromedp tests covering: anchor IDs, edit-on-github link href, theme toggle persistence + accent injection, native catalog page, proxied pattern interactivity.

## Backward compatibility

Every change is additive. Existing tinkerdown sites with no `routes:` / `version_prefix` / `source_repo` frontmatter behave identically. Only the gzip-middleware refactor is internal and visible only via Unwrap()-aware handlers.