### PR TITLE
fix(server): emit wss:// for HTTPS-served pages (Phase 5 docs site G11)

### DIFF
--- a/internal/server/playground.go
+++ b/internal/server/playground.go
@@ -170,7 +170,7 @@ func (h *PlaygroundHandler) HandlePreview(w http.ResponseWriter, r *http.Request
 	}
 
 	// Render the page
-	html := h.renderPage(session.Page, r.Host)
+	html := h.renderPage(session.Page, r.Host, detectWSScheme(r))
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(html))
@@ -200,9 +200,9 @@ func (h *PlaygroundHandler) HandlePreviewWS(w http.ResponseWriter, r *http.Reque
 }
 
 // renderPage renders a page to HTML using the server's rendering logic.
-func (h *PlaygroundHandler) renderPage(page *tinkerdown.Page, host string) string {
+func (h *PlaygroundHandler) renderPage(page *tinkerdown.Page, host string, wsScheme string) string {
 	// Use the server's renderPage method for consistent output
-	return h.server.renderPage(page, "/playground/preview", host)
+	return h.server.renderPage(page, "/playground/preview", host, wsScheme)
 }
 
 // jsonError sends a JSON error response.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -695,8 +695,19 @@ func (s *Server) servePage(w http.ResponseWriter, r *http.Request, route *Route)
 // generic reverse proxies all set it on TLS-terminated requests),
 // then fall back to r.TLS for direct HTTPS servers, then "ws".
 func detectWSScheme(r *http.Request) string {
-	if proto := r.Header.Get("X-Forwarded-Proto"); proto == "https" {
-		return "wss"
+	// When X-Forwarded-Proto is present, it is authoritative — the
+	// proxy knows what scheme the client actually spoke. We must NOT
+	// fall through to the r.TLS check because a TLS-terminated server
+	// behind a proxy that talks plain http to its backend would then
+	// emit wss:// for clients that connected over plain http.
+	//
+	// EqualFold defends against proxies that send "HTTPS" / "Https";
+	// net/http canonicalises header *names* but not *values*.
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		if strings.EqualFold(proto, "https") {
+			return "wss"
+		}
+		return "ws"
 	}
 	if r.TLS != nil {
 		return "wss"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -682,12 +682,33 @@ func (s *Server) servePage(w http.ResponseWriter, r *http.Request, route *Route)
 	// TODO: Add WebSocket support for interactivity
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	html := s.renderPage(route.Page, r.URL.Path, r.Host)
+	html := s.renderPage(route.Page, r.URL.Path, r.Host, detectWSScheme(r))
 	w.Write([]byte(html))
 }
 
-// renderPage renders a page to HTML.
-func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host string) string {
+// detectWSScheme returns the appropriate WebSocket URL scheme ("wss"
+// or "ws") for the request. A page served over HTTPS must connect to
+// a wss:// endpoint or browsers reject the upgrade as mixed-content,
+// silently breaking every interactive block on the page.
+//
+// We trust X-Forwarded-Proto from the edge first (fly, cloudflare,
+// generic reverse proxies all set it on TLS-terminated requests),
+// then fall back to r.TLS for direct HTTPS servers, then "ws".
+func detectWSScheme(r *http.Request) string {
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto == "https" {
+		return "wss"
+	}
+	if r.TLS != nil {
+		return "wss"
+	}
+	return "ws"
+}
+
+// renderPage renders a page to HTML. wsScheme should be "ws" for
+// http-served pages and "wss" for https-served pages — see
+// detectWSScheme. Passing the wrong scheme silently breaks every
+// interactive block under HTTPS via mixed-content rejection.
+func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host string, wsScheme string) string {
 	// Render code blocks with metadata for client discovery
 	content := s.renderContent(page)
 
@@ -746,8 +767,9 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
 		%s
 	`, breadcrumbsHTML, content, editLinkHTML, prevNextHTML)
 
-	// Build WebSocket URL from host with page path for multi-page routing
-	wsURL := fmt.Sprintf("ws://%s/ws?page=%s", host, url.QueryEscape(currentPath))
+	// Build WebSocket URL from host with page path for multi-page routing.
+	// Scheme MUST match the page's request scheme — see detectWSScheme.
+	wsURL := fmt.Sprintf("%s://%s/ws?page=%s", wsScheme, host, url.QueryEscape(currentPath))
 
 	// Conditionally include Chart.js for pages with chart annotations
 	chartScript := ""

--- a/internal/server/ws_scheme_test.go
+++ b/internal/server/ws_scheme_test.go
@@ -53,13 +53,26 @@ func TestDetectWSScheme(t *testing.T) {
 			want: "ws",
 		},
 		{
-			// Edge sets X-Forwarded-Proto: http and TLS isn't terminated —
-			// stay plain. We don't try to second-guess the edge.
-			name: "x-forwarded-proto http takes priority over absent TLS",
+			// The case where the priority order between the two checks
+			// actually matters: the proxy advertises plain http but our
+			// listening socket happens to be TLS. The proxy's signal is
+			// authoritative — it knows what the client actually spoke.
+			name: "x-forwarded-proto http overrides r.TLS (proxy is authoritative)",
 			req: &http.Request{
 				Header: http.Header{"X-Forwarded-Proto": []string{"http"}},
+				TLS:    &tls.ConnectionState{},
 			},
 			want: "ws",
+		},
+		{
+			// Defensive: net/http canonicalises header names but not
+			// values. Most proxies send lowercase, but EqualFold guards
+			// against the rare ones that don't.
+			name: "x-forwarded-proto HTTPS (uppercase) still detected as wss",
+			req: &http.Request{
+				Header: http.Header{"X-Forwarded-Proto": []string{"HTTPS"}},
+			},
+			want: "wss",
 		},
 	}
 	for _, c := range cases {

--- a/internal/server/ws_scheme_test.go
+++ b/internal/server/ws_scheme_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+// TestDetectWSScheme covers the full matrix of how a tinkerdown server
+// might learn that the public-facing scheme is HTTPS:
+//   - X-Forwarded-Proto from an edge / reverse proxy (fly, cloudflare,
+//     nginx, traefik). Most production deployments hit this path.
+//   - r.TLS != nil for a server terminating TLS itself.
+//   - Neither set: fall back to plain ws.
+//
+// A regression here means every interactive block on the page silently
+// fails under HTTPS — chrome rejects mixed-content WS upgrades without
+// any user-visible error. The browser's DevTools console is the only
+// signal, which most operators won't see.
+func TestDetectWSScheme(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *http.Request
+		want string
+	}{
+		{
+			name: "x-forwarded-proto https (fly/cloudflare/etc)",
+			req: &http.Request{
+				Header: http.Header{"X-Forwarded-Proto": []string{"https"}},
+			},
+			want: "wss",
+		},
+		{
+			name: "x-forwarded-proto http",
+			req: &http.Request{
+				Header: http.Header{"X-Forwarded-Proto": []string{"http"}},
+			},
+			want: "ws",
+		},
+		{
+			name: "direct https (r.TLS set)",
+			req: &http.Request{
+				Header: http.Header{},
+				TLS:    &tls.ConnectionState{},
+			},
+			want: "wss",
+		},
+		{
+			name: "plain http, no proxy",
+			req: &http.Request{
+				Header: http.Header{},
+			},
+			want: "ws",
+		},
+		{
+			// Edge sets X-Forwarded-Proto: http and TLS isn't terminated —
+			// stay plain. We don't try to second-guess the edge.
+			name: "x-forwarded-proto http takes priority over absent TLS",
+			req: &http.Request{
+				Header: http.Header{"X-Forwarded-Proto": []string{"http"}},
+			},
+			want: "ws",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := detectWSScheme(c.req); got != c.want {
+				t.Errorf("detectWSScheme = %q, want %q", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Hard-coded `ws://` in the WebSocket URL meta tag breaks every interactive block when the page is loaded over HTTPS — Chrome rejects the mixed-content WS upgrade silently.
- New `detectWSScheme(r)` helper resolves the scheme from `X-Forwarded-Proto` (set by fly, cloudflare, generic reverse proxies on TLS-terminated requests), then `r.TLS` for direct HTTPS servers, then `ws`.
- `renderPage` takes the scheme as a new parameter; `servePage` and the playground render both pass it.
- Unit tests cover the full matrix: edge-set X-Forwarded-Proto (https + http), direct HTTPS (`r.TLS != nil`), no proxy header.

## Why

Surfaced during Phase 5 of the livetemplate/docs build — first time the docs site uses `lvt-source` blocks. https://livetemplate-docs-staging.fly.dev/patterns/ and /recipes/patterns-stats both hung at the "Connecting…" placeholder. The bug is generic: any HTTPS-served tinkerdown site loses every interactive feature.

## Test plan

- [x] `go test ./internal/server/...` (full server suite green)
- [x] New `TestDetectWSScheme` covers all 5 scheme-detection cases
- [ ] Cut release; redeploy livetemplate-docs-staging; e2e suite `TestRecipe1_*` and `TestRecipe3_*` pass post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)