### PR TITLE
feat(server): SEO endpoints + G4 perf fix

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -436,9 +436,16 @@ func (c *Config) ValidateWebhooks() error {
 
 // SiteConfig holds site-level configuration
 type SiteConfig struct {
-	Home       string `yaml:"home"`        // Homepage markdown file (e.g., "index.md")
-	Logo       string `yaml:"logo"`        // Logo path (e.g., "/assets/logo.svg")
-	Repository string `yaml:"repository"`  // GitHub repository URL
+	Home       string `yaml:"home"`       // Homepage markdown file (e.g., "index.md")
+	Logo       string `yaml:"logo"`       // Logo path (e.g., "/assets/logo.svg")
+	Repository string `yaml:"repository"` // GitHub repository URL
+
+	// URL is the canonical absolute base URL of the deployed site
+	// (e.g., "https://livetemplate.fly.dev"), with NO trailing slash.
+	// When set, sitemap.xml emits absolute URLs and OpenGraph meta tags
+	// include og:url. When empty, sitemap entries use relative paths and
+	// og:url is omitted.
+	URL string `yaml:"url,omitempty"`
 }
 
 // NavSection represents a navigation section with pages

--- a/internal/server/perf_render_test.go
+++ b/internal/server/perf_render_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+// G4 (Phase 1 docs-site learning): every external script in the rendered
+// page must be `defer`-loaded so the parser is not blocked. This locks the
+// regression-target — if a future contributor re-introduces a synchronous
+// <script src=...> at the bottom of a page, this test fires.
+func TestRenderedPageScriptTagsAreDeferred(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "index.md"), []byte("---\ntitle: Home\n---\n# Home\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Site = &config.SiteConfig{Home: "index.md"}
+	cfg.Navigation = []config.NavSection{{
+		Title: "Top",
+		Pages: []config.NavPage{{Title: "Home", Path: "index.md"}},
+	}}
+
+	srv := NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+
+	// Every <script src=...> MUST carry the `defer` attribute.
+	for _, line := range strings.Split(body, "\n") {
+		l := strings.TrimSpace(line)
+		if !strings.HasPrefix(l, "<script") {
+			continue
+		}
+		if !strings.Contains(l, "src=") {
+			continue // inline scripts aren't required to defer
+		}
+		if !strings.Contains(l, "defer") {
+			t.Errorf("script tag is render-blocking (no defer): %s", l)
+		}
+	}
+}
+
+// G4: Mermaid is conditional on HasMermaid — pages without mermaid blocks
+// must not pay the ~3.3MB Mermaid runtime cost.
+func TestMermaidScriptOmittedFromPagesWithoutMermaidBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	plainContent := `---
+title: "Plain"
+---
+# No diagrams here
+
+Just prose, with a regular ` + "`code`" + ` span.
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "plain.md"), []byte(plainContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Site = &config.SiteConfig{Home: "plain.md"}
+	cfg.Navigation = []config.NavSection{{
+		Title: "Top",
+		Pages: []config.NavPage{{Title: "Plain", Path: "plain.md"}},
+	}}
+
+	srv := NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/plain", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "/assets/mermaid.js") {
+		t.Errorf("mermaid script was included on a page with no ```mermaid blocks")
+	}
+}
+
+func TestMermaidScriptIncludedOnPagesWithMermaidBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mermaidContent := `---
+title: "Diagram"
+---
+# Flow
+
+` + "```mermaid\nflowchart LR\n  A --> B\n```" + `
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "diagram.md"), []byte(mermaidContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Site = &config.SiteConfig{Home: "diagram.md"}
+	cfg.Navigation = []config.NavSection{{
+		Title: "Top",
+		Pages: []config.NavPage{{Title: "Diagram", Path: "diagram.md"}},
+	}}
+
+	srv := NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/diagram", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "/assets/mermaid.js") {
+		t.Errorf("mermaid script missing on a page that contains ```mermaid blocks")
+	}
+	if !strings.Contains(body, `<script defer src="/assets/mermaid.js">`) {
+		t.Errorf("mermaid script must be deferred: %s", body)
+	}
+}

--- a/internal/server/seo.go
+++ b/internal/server/seo.go
@@ -1,0 +1,180 @@
+// SEO endpoints: sitemap.xml and robots.txt.
+//
+// These are generic features available to any tinkerdown site. They derive
+// content from the site's discovered pages (via siteManager) and the
+// canonical URL declared in `site.url` of tinkerdown.yaml. When `site.url`
+// is unset, sitemap entries fall back to relative paths and robots.txt
+// omits its Sitemap reference.
+
+package server
+
+import (
+	"encoding/xml"
+	"fmt"
+	"html"
+	"net/http"
+	"strings"
+
+	"github.com/livetemplate/tinkerdown"
+)
+
+// buildSEOTags returns the HTML <meta> tags injected into the page <head>.
+// It emits a description, OpenGraph properties, and Twitter card tags using
+// frontmatter overrides where present and falling back to site-level config.
+// Returns an empty string when there's nothing useful to emit.
+func (s *Server) buildSEOTags(page *tinkerdown.Page, currentPath string) string {
+	if page == nil {
+		return ""
+	}
+
+	// Resolve description: page > site.
+	description := page.Description
+	if description == "" && s.config.Description != "" {
+		description = s.config.Description
+	}
+
+	// Resolve canonical absolute URL when site.url is configured.
+	baseURL := ""
+	siteName := s.config.Title
+	siteLogo := ""
+	if s.config.Site != nil {
+		baseURL = strings.TrimRight(s.config.Site.URL, "/")
+		siteLogo = s.config.Site.Logo
+	}
+	canonicalURL := ""
+	if baseURL != "" {
+		canonicalURL = baseURL + currentPath
+	}
+
+	// Resolve image: page > site logo. If image is a relative path and we
+	// have a baseURL, prefix it so social platforms can resolve it.
+	image := page.Image
+	if image == "" {
+		image = siteLogo
+	}
+	if image != "" && !strings.HasPrefix(image, "http://") && !strings.HasPrefix(image, "https://") {
+		if baseURL != "" {
+			if !strings.HasPrefix(image, "/") {
+				image = "/" + image
+			}
+			image = baseURL + image
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("\n")
+
+	if description != "" {
+		fmt.Fprintf(&b, `    <meta name="description" content="%s">`+"\n", html.EscapeString(description))
+	}
+	if canonicalURL != "" {
+		fmt.Fprintf(&b, `    <link rel="canonical" href="%s">`+"\n", html.EscapeString(canonicalURL))
+	}
+
+	// OpenGraph tags
+	fmt.Fprintf(&b, `    <meta property="og:type" content="website">`+"\n")
+	fmt.Fprintf(&b, `    <meta property="og:title" content="%s">`+"\n", html.EscapeString(page.Title))
+	if description != "" {
+		fmt.Fprintf(&b, `    <meta property="og:description" content="%s">`+"\n", html.EscapeString(description))
+	}
+	if canonicalURL != "" {
+		fmt.Fprintf(&b, `    <meta property="og:url" content="%s">`+"\n", html.EscapeString(canonicalURL))
+	}
+	if siteName != "" {
+		fmt.Fprintf(&b, `    <meta property="og:site_name" content="%s">`+"\n", html.EscapeString(siteName))
+	}
+	if image != "" {
+		fmt.Fprintf(&b, `    <meta property="og:image" content="%s">`+"\n", html.EscapeString(image))
+	}
+
+	// Twitter card — summary_large_image when an image is present, else summary.
+	twitterCard := "summary"
+	if image != "" {
+		twitterCard = "summary_large_image"
+	}
+	fmt.Fprintf(&b, `    <meta name="twitter:card" content="%s">`+"\n", twitterCard)
+	fmt.Fprintf(&b, `    <meta name="twitter:title" content="%s">`+"\n", html.EscapeString(page.Title))
+	if description != "" {
+		fmt.Fprintf(&b, `    <meta name="twitter:description" content="%s">`+"\n", html.EscapeString(description))
+	}
+	if image != "" {
+		fmt.Fprintf(&b, `    <meta name="twitter:image" content="%s">`+"\n", html.EscapeString(image))
+	}
+
+	return b.String()
+}
+
+// urlEntry represents a single <url> in a sitemap.
+type urlEntry struct {
+	XMLName xml.Name `xml:"url"`
+	Loc     string   `xml:"loc"`
+}
+
+// urlSet is the root <urlset> element.
+type urlSet struct {
+	XMLName xml.Name   `xml:"urlset"`
+	Xmlns   string     `xml:"xmlns,attr"`
+	URLs    []urlEntry `xml:"url"`
+}
+
+// serveSitemap returns a sitemap.xml derived from discovered pages.
+// In headless mode (no site manager) this returns 404 since there are no
+// pages to enumerate.
+func (s *Server) serveSitemap(w http.ResponseWriter, _ *http.Request) {
+	if s.siteManager == nil {
+		http.Error(w, "sitemap unavailable in headless mode", http.StatusNotFound)
+		return
+	}
+
+	baseURL := ""
+	if s.config.Site != nil {
+		baseURL = strings.TrimRight(s.config.Site.URL, "/")
+	}
+
+	pages := s.siteManager.AllPages()
+	entries := make([]urlEntry, 0, len(pages))
+	for _, p := range pages {
+		if p == nil || p.Path == "" {
+			continue
+		}
+		loc := p.Path
+		if baseURL != "" {
+			loc = baseURL + p.Path
+		}
+		entries = append(entries, urlEntry{Loc: loc})
+	}
+
+	doc := urlSet{
+		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
+		URLs:  entries,
+	}
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+	if _, err := w.Write([]byte(xml.Header)); err != nil {
+		return
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		http.Error(w, "failed to encode sitemap", http.StatusInternalServerError)
+		return
+	}
+}
+
+// serveRobots returns a robots.txt that allows all by default and references
+// the sitemap when site.url is configured.
+func (s *Server) serveRobots(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	body := "User-agent: *\nAllow: /\n"
+	if s.config.Site != nil {
+		base := strings.TrimRight(s.config.Site.URL, "/")
+		if base != "" {
+			body += fmt.Sprintf("\nSitemap: %s/sitemap.xml\n", base)
+		}
+	}
+
+	if _, err := w.Write([]byte(body)); err != nil {
+		return
+	}
+}

--- a/internal/server/seo_test.go
+++ b/internal/server/seo_test.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/tinkerdown"
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+func TestServeRobotsAllowsAllByDefault(t *testing.T) {
+	srv := New(t.TempDir())
+
+	req := httptest.NewRequest("GET", "/robots.txt", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !strings.Contains(w.Body.String(), "User-agent: *") {
+		t.Errorf("robots.txt missing User-agent line: %q", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Allow: /") {
+		t.Errorf("robots.txt missing Allow: /: %q", w.Body.String())
+	}
+}
+
+func TestServeRobotsIncludesSitemapWhenSiteURLConfigured(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Site = &config.SiteConfig{URL: "https://example.com"}
+	srv := NewWithConfig(t.TempDir(), cfg)
+
+	req := httptest.NewRequest("GET", "/robots.txt", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Sitemap: https://example.com/sitemap.xml") {
+		t.Errorf("missing Sitemap reference: %q", body)
+	}
+}
+
+func TestServeRobotsTrimsTrailingSlash(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Site = &config.SiteConfig{URL: "https://example.com/"}
+	srv := NewWithConfig(t.TempDir(), cfg)
+
+	req := httptest.NewRequest("GET", "/robots.txt", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if !strings.Contains(w.Body.String(), "https://example.com/sitemap.xml") {
+		t.Errorf("trailing slash not trimmed: %q", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "https://example.com//sitemap.xml") {
+		t.Errorf("double-slash leaked: %q", w.Body.String())
+	}
+}
+
+func TestServeSitemapEnumeratesPagesInSiteMode(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "index.md"), []byte("---\ntitle: Home\n---\n# Home\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "about.md"), []byte("---\ntitle: About\n---\n# About\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Site = &config.SiteConfig{Home: "index.md", URL: "https://docs.example.com"}
+	cfg.Navigation = []config.NavSection{
+		{
+			Title: "Top",
+			Path:  "",
+			Pages: []config.NavPage{
+				{Title: "Home", Path: "index.md"},
+				{Title: "About", Path: "about.md"},
+			},
+		},
+	}
+
+	srv := NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/sitemap.xml", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"<urlset",
+		"https://docs.example.com/about",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("sitemap missing %q\n--- body ---\n%s", want, body)
+		}
+	}
+}
+
+func TestServeSitemap404InHeadlessMode(t *testing.T) {
+	srv := New(t.TempDir()) // No site manager
+	req := httptest.NewRequest("GET", "/sitemap.xml", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestBuildSEOTagsFallsBackToSiteDescription(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Title = "Docs"
+	cfg.Description = "Site default description"
+	cfg.Site = &config.SiteConfig{URL: "https://example.com"}
+	srv := NewWithConfig(t.TempDir(), cfg)
+
+	page := &tinkerdown.Page{Title: "Home"}
+	tags := srv.buildSEOTags(page, "/")
+
+	if !strings.Contains(tags, `name="description" content="Site default description"`) {
+		t.Errorf("missing site description fallback: %s", tags)
+	}
+	if !strings.Contains(tags, `property="og:title" content="Home"`) {
+		t.Errorf("missing og:title: %s", tags)
+	}
+	if !strings.Contains(tags, `property="og:url" content="https://example.com/"`) {
+		t.Errorf("missing canonical og:url: %s", tags)
+	}
+	if !strings.Contains(tags, `property="og:site_name" content="Docs"`) {
+		t.Errorf("missing og:site_name: %s", tags)
+	}
+}
+
+func TestBuildSEOTagsPageOverridesSite(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Description = "Site default"
+	cfg.Site = &config.SiteConfig{URL: "https://example.com"}
+	srv := NewWithConfig(t.TempDir(), cfg)
+
+	page := &tinkerdown.Page{
+		Title:       "Recipe",
+		Description: "Page-specific description",
+		Image:       "/assets/recipe.png",
+	}
+	tags := srv.buildSEOTags(page, "/recipes/x")
+
+	if !strings.Contains(tags, `content="Page-specific description"`) {
+		t.Errorf("page description should win over site: %s", tags)
+	}
+	if !strings.Contains(tags, `og:image" content="https://example.com/assets/recipe.png"`) {
+		t.Errorf("relative image should be made absolute via baseURL: %s", tags)
+	}
+	if !strings.Contains(tags, `twitter:card" content="summary_large_image"`) {
+		t.Errorf("twitter card should upgrade to summary_large_image when image present: %s", tags)
+	}
+}
+
+func TestBuildSEOTagsEscapesHTML(t *testing.T) {
+	srv := New(t.TempDir())
+	page := &tinkerdown.Page{
+		Title:       `"<script>"`,
+		Description: `evil & "html"`,
+	}
+	tags := srv.buildSEOTags(page, "/x")
+
+	if strings.Contains(tags, "<script>") {
+		t.Errorf("title injection not escaped: %s", tags)
+	}
+	if !strings.Contains(tags, "&amp;") || !strings.Contains(tags, "&#34;") {
+		t.Errorf("description not properly HTML-escaped: %s", tags)
+	}
+}
+
+func TestRenderedPageIncludesSEOTags(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pageContent := `---
+title: "Hello"
+description: "A short page"
+---
+# Hello
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "hello.md"), []byte(pageContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Site = &config.SiteConfig{Home: "hello.md", URL: "https://example.com"}
+	cfg.Navigation = []config.NavSection{{
+		Title: "Top",
+		Pages: []config.NavPage{{Title: "Hello", Path: "hello.md"}},
+	}}
+
+	srv := NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/hello", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	for _, want := range []string{
+		`<meta name="description" content="A short page">`,
+		`<meta property="og:title" content="Hello">`,
+		`<meta property="og:url" content="https://example.com/hello">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered HTML missing %q", want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -400,6 +400,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SEO endpoints (always available; sitemap returns 404 in headless mode
+	// since there are no pages to enumerate, but robots.txt is still useful).
+	if r.URL.Path == "/sitemap.xml" {
+		s.serveSitemap(w, r)
+		return
+	}
+	if r.URL.Path == "/robots.txt" {
+		s.serveRobots(w, r)
+		return
+	}
+
 	// Serve REST API endpoints
 	if strings.HasPrefix(r.URL.Path, "/api/sources/") && s.apiRoutes != nil {
 		s.apiRoutes.ServeHTTP(w, r)
@@ -782,12 +793,57 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
 	// Scheme MUST match the page's request scheme — see detectWSScheme.
 	wsURL := fmt.Sprintf("%s://%s/ws?page=%s", wsScheme, host, url.QueryEscape(currentPath))
 
-	// Conditionally include Chart.js for pages with chart annotations
+	// Build per-page SEO meta tags (OG, Twitter card, description, canonical).
+	// Falls back to site-level config when frontmatter fields are absent.
+	seoTags := s.buildSEOTags(page, currentPath)
+
+	// Conditionally include Mermaid (~3.3MB) only when the page has
+	// ```mermaid fenced blocks. HasMermaid is set by the parser AST walk.
+	mermaidScript := ""
+	if page.HasMermaid {
+		mermaidScript = `
+    <!-- Mermaid.js for diagrams (embedded) -->
+    <script defer src="/assets/mermaid.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            mermaid.initialize({
+                startOnLoad: false,
+                theme: document.documentElement.classList.contains('theme-dark') ? 'dark' : 'default',
+                flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'basis' },
+                sequence: {
+                    diagramMarginX: 50, diagramMarginY: 10, actorMargin: 50,
+                    width: 150, height: 65, boxMargin: 10, boxTextMargin: 5,
+                    noteMargin: 10, messageMargin: 35, mirrorActors: true, useMaxWidth: true
+                }
+            });
+
+            // Convert ` + "`" + `` + "`" + `` + "`" + `mermaid code blocks into rendered diagrams.
+            document.querySelectorAll('code.language-mermaid').forEach(function(codeBlock) {
+                const mermaidDiv = document.createElement('div');
+                mermaidDiv.className = 'mermaid';
+                mermaidDiv.textContent = codeBlock.textContent;
+                const preBlock = codeBlock.parentElement;
+                preBlock.parentNode.replaceChild(mermaidDiv, preBlock);
+            });
+            mermaid.run();
+        });
+
+        document.addEventListener('themeChanged', function(e) {
+            mermaid.initialize({ theme: e.detail.theme === 'dark' ? 'dark' : 'default' });
+            mermaid.run();
+        });
+    </script>`
+	}
+
+	// Conditionally include Chart.js for pages with chart annotations.
+	// defer makes the external script non-render-blocking. The inline init
+	// script registers a DOMContentLoaded listener, which fires after defer
+	// scripts execute, so Chart will be defined when the listener runs.
 	chartScript := ""
 	if page.HasCharts {
 		chartScript = `
     <!-- Chart.js for data visualization (embedded) -->
-    <script src="/assets/chart.js"></script>
+    <script defer src="/assets/chart.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             var isDark = document.documentElement.classList.contains('theme-dark');
@@ -910,7 +966,7 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
     <meta name="tinkerdown-ws-url" content="%s">
     <meta name="tinkerdown-debug" content="true">
     <meta name="tinkerdown-sidebar" content="%t">
-    <title>%s</title>
+    <title>%s</title>%s
     <!-- PicoCSS - Semantic/Classless CSS Framework (embedded) -->
     <link rel="stylesheet" href="/assets/pico.css">
     <link rel="stylesheet" href="/assets/tinkerdown-client.css">
@@ -2501,19 +2557,20 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
         })();
     </script>
 
-    <script src="/assets/tinkerdown-client.js"></script>
+    <script defer src="/assets/tinkerdown-client.js"></script>
 
-    <!-- Prism.js for syntax highlighting (embedded) -->
-    <script src="/assets/prism.js"></script>
-    <script src="/assets/prism-go.js"></script>
-    <script src="/assets/prism-javascript.js"></script>
-    <script src="/assets/prism-jsx.js"></script>
-    <script src="/assets/prism-markup.js"></script>
-    <script src="/assets/prism-css.js"></script>
-    <script src="/assets/prism-yaml.js"></script>
-    <script src="/assets/prism-json.js"></script>
-    <script src="/assets/prism-bash.js"></script>
-    <script src="/assets/prism-markdown.js"></script>
+    <!-- Prism.js for syntax highlighting (embedded). defer eliminates render-block
+         and preserves source order so language plugins load after prism core. -->
+    <script defer src="/assets/prism.js"></script>
+    <script defer src="/assets/prism-go.js"></script>
+    <script defer src="/assets/prism-javascript.js"></script>
+    <script defer src="/assets/prism-jsx.js"></script>
+    <script defer src="/assets/prism-markup.js"></script>
+    <script defer src="/assets/prism-css.js"></script>
+    <script defer src="/assets/prism-yaml.js"></script>
+    <script defer src="/assets/prism-json.js"></script>
+    <script defer src="/assets/prism-bash.js"></script>
+    <script defer src="/assets/prism-markdown.js"></script>
     <script>
         // Highlight all code blocks on page load
         document.addEventListener('DOMContentLoaded', function() {
@@ -2521,68 +2578,10 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
         });
     </script>
 
-    <!-- Mermaid.js for diagrams (embedded) -->
-    <script src="/assets/mermaid.js"></script>
-    <script>
-        // Initialize Mermaid for diagram rendering
-        mermaid.initialize({
-            startOnLoad: false, // We'll trigger manually after conversion
-            theme: document.documentElement.classList.contains('theme-dark') ? 'dark' : 'default',
-            flowchart: {
-                useMaxWidth: true,
-                htmlLabels: true,
-                curve: 'basis'
-            },
-            sequence: {
-                diagramMarginX: 50,
-                diagramMarginY: 10,
-                actorMargin: 50,
-                width: 150,
-                height: 65,
-                boxMargin: 10,
-                boxTextMargin: 5,
-                noteMargin: 10,
-                messageMargin: 35,
-                mirrorActors: true,
-                useMaxWidth: true
-            }
-        });
-
-        // Convert mermaid code blocks to rendered diagrams
-        document.addEventListener('DOMContentLoaded', function() {
-            // Find all code blocks with language-mermaid class
-            const mermaidBlocks = document.querySelectorAll('code.language-mermaid');
-
-            mermaidBlocks.forEach(function(codeBlock) {
-                // Get the mermaid code
-                const code = codeBlock.textContent;
-
-                // Create a new div for the rendered diagram
-                const mermaidDiv = document.createElement('div');
-                mermaidDiv.className = 'mermaid';
-                mermaidDiv.textContent = code;
-
-                // Replace the pre>code structure with just the mermaid div
-                const preBlock = codeBlock.parentElement;
-                preBlock.parentNode.replaceChild(mermaidDiv, preBlock);
-            });
-
-            // Now render all mermaid diagrams
-            mermaid.run();
-        });
-
-        // Re-initialize Mermaid when theme changes
-        document.addEventListener('themeChanged', function(e) {
-            mermaid.initialize({
-                theme: e.detail.theme === 'dark' ? 'dark' : 'default'
-            });
-            // Re-render all diagrams
-            mermaid.run();
-        });
-    </script>
+    %s
 %s
 </body>
-</html>`, wsURL, showSidebar, page.Title, stylingOverrideCSS, sidebar, contentWithNav, defaultTheme, chartScript)
+</html>`, wsURL, showSidebar, page.Title, seoTags, stylingOverrideCSS, sidebar, contentWithNav, defaultTheme, mermaidScript, chartScript)
 
 	return html
 }

--- a/page.go
+++ b/page.go
@@ -113,6 +113,9 @@ func ParseFile(path string) (*Page, error) {
 		page.ScheduleWarnings = fm.ScheduleWarnings
 	}
 	page.HasCharts = fm.HasCharts
+	page.HasMermaid = fm.HasMermaid
+	page.Description = fm.Description
+	page.Image = fm.Image
 
 	// Build blocks (pass source file for error context)
 	if err := page.buildBlocks(codeBlocks, absPath); err != nil {
@@ -260,6 +263,9 @@ func BuildPage(id, sourceFile string, content []byte) (*Page, error) {
 		page.ScheduleWarnings = fm.ScheduleWarnings
 	}
 	page.HasCharts = fm.HasCharts
+	page.HasMermaid = fm.HasMermaid
+	page.Description = fm.Description
+	page.Image = fm.Image
 
 	// Build blocks
 	if err := page.buildBlocks(codeBlocks, sourceFile); err != nil {

--- a/parser.go
+++ b/parser.go
@@ -96,10 +96,12 @@ type ParamDef struct {
 // Frontmatter represents the YAML frontmatter at the top of a markdown file.
 type Frontmatter struct {
 	// Page metadata
-	Title   string      `yaml:"title"`
-	Type    string      `yaml:"type"`    // tutorial, guide, reference, playground
-	Persist PersistMode `yaml:"persist"` // none, localstorage, server
-	Steps   int         `yaml:"steps"`
+	Title       string      `yaml:"title"`
+	Description string      `yaml:"description,omitempty"` // Used for <meta name="description"> + og:description
+	Image       string      `yaml:"image,omitempty"`       // Path/URL used for og:image (falls back to site logo)
+	Type        string      `yaml:"type"`                  // tutorial, guide, reference, playground
+	Persist     PersistMode `yaml:"persist"`               // none, localstorage, server
+	Steps       int         `yaml:"steps"`
 
 	// Top-level convenience options
 	Sidebar *bool `yaml:"sidebar,omitempty"` // Show navigation sidebar (overrides features.sidebar)
@@ -137,6 +139,9 @@ type Frontmatter struct {
 
 	// HasCharts indicates the page has {chart:...} annotations (populated during parsing)
 	HasCharts bool `yaml:"-"`
+
+	// HasMermaid indicates the page has ```mermaid fenced blocks (populated during parsing)
+	HasMermaid bool `yaml:"-"`
 }
 
 // CodeBlock represents a code block extracted from markdown.
@@ -188,6 +193,13 @@ func ParseMarkdown(content []byte) (*Frontmatter, []*CodeBlock, string, error) {
 				// This is a livemdtools block - collect it and map it to AST node
 				codeBlocks = append(codeBlocks, block)
 				blockMap[n] = block
+			} else if fenced.Info != nil {
+				// Non-livemdtools fenced block — check for mermaid so the
+				// server can conditionally load the heavy Mermaid runtime.
+				info := strings.Fields(string(fenced.Info.Text(remaining)))
+				if len(info) > 0 && info[0] == "mermaid" {
+					frontmatter.HasMermaid = true
+				}
 			}
 		}
 
@@ -1124,6 +1136,11 @@ func ParseMarkdownWithPartials(content []byte, baseDir string) (*Frontmatter, []
 			if block != nil {
 				codeBlocks = append(codeBlocks, block)
 				blockMap[n] = block
+			} else if fenced.Info != nil {
+				info := strings.Fields(string(fenced.Info.Text(processed)))
+				if len(info) > 0 && info[0] == "mermaid" {
+					frontmatter.HasMermaid = true
+				}
 			}
 		}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1037,6 +1037,41 @@ func TestProcessCharts(t *testing.T) {
 	}
 }
 
+func TestParseMarkdownDetectsMermaid(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "page with mermaid block",
+			content: "---\ntitle: \"Diagram\"\n---\n\n# Flow\n\n```mermaid\nflowchart LR\n  A --> B\n```\n",
+			want: true,
+		},
+		{
+			name:    "page without mermaid block",
+			content: "---\ntitle: \"No Diagram\"\n---\n\n# Just text\n\n```go\nfmt.Println(\"hi\")\n```\n",
+			want:    false,
+		},
+		{
+			name:    "no fenced blocks at all",
+			content: "---\ntitle: \"Plain\"\n---\n\nJust prose, no code.\n",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fm, _, _, err := ParseMarkdown([]byte(tc.content))
+			if err != nil {
+				t.Fatalf("ParseMarkdown failed: %v", err)
+			}
+			if fm.HasMermaid != tc.want {
+				t.Errorf("HasMermaid = %v, want %v", fm.HasMermaid, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseMarkdownWithCharts(t *testing.T) {
 	content := []byte(`---
 title: "Chart Test"

--- a/tinkerdown.go
+++ b/tinkerdown.go
@@ -8,6 +8,8 @@ import "github.com/livetemplate/tinkerdown/internal/schedule"
 type Page struct {
 	ID                string
 	Title             string
+	Description       string // From frontmatter; used for <meta description> + og:description
+	Image             string // From frontmatter; used for og:image
 	Type              string // tutorial, guide, reference, playground
 	SourceFile        string // Absolute path to source .md file (for error messages)
 	SourceRepo        string // Origin GitHub repo URL from frontmatter (for edit link)
@@ -33,6 +35,12 @@ type Page struct {
 
 	// HasCharts indicates the page has chart annotations requiring Chart.js
 	HasCharts bool
+
+	// HasMermaid indicates the page contains ```mermaid fenced blocks
+	// requiring the Mermaid runtime (~3.3MB). Used by the server to
+	// conditionally inject the script and avoid penalising pages without
+	// any diagrams.
+	HasMermaid bool
 }
 
 // PageConfig contains configuration for a page.


### PR DESCRIPTION
## Summary
- Generic tinkerdown SEO primitives — `/sitemap.xml`, `/robots.txt`, OpenGraph + Twitter card meta in `<head>` — driven by a new `site.url` config field and optional `description` / `image` frontmatter (with site-level fallbacks).
- G4 perf fix discovered against the docs site at staging: every external `<script src=...>` is now `defer`-loaded, and the ~3.3MB Mermaid runtime is gated on a new `Page.HasMermaid` flag (set during the existing AST walk for fenced code blocks) so pages without diagrams don't pay for it.

Both changes are generic tinkerdown features. Neither hardcodes anything docs-site-specific.

## Why ship together
Both unblock the docs site's launch acceptance bar — Lighthouse perf ≥90 (G4) and the OG meta needed for shareable URLs (SEO). Smaller PRs were possible but every overlap is in the same files (`server.go`, `parser.go`, `page.go`, `tinkerdown.go`), and they ship in the same release either way.

## Test plan
- [x] `go test ./internal/server/ ./internal/config/` — green
- [x] 9 new SEO tests cover both endpoints, the OG fallback chain (page → site), HTML escaping, and end-to-end rendered-page injection
- [x] 3 new perf tests pin G4: every `<script src=…>` must `defer`; mermaid runtime omitted when no `mermaid` blocks; included when present
- [x] 3 new parser unit tests for HasMermaid detection
- [ ] Will be re-verified end-to-end against the docs site staging deploy after merge + tag + Dockerfile pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)