### PR TITLE
feat(diagrams): server-side mermaid pre-render via Kroki (G16)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -488,6 +488,19 @@ type FeaturesConfig struct {
 	HotReload bool `yaml:"hot_reload"`
 	Sidebar   bool `yaml:"sidebar"`  // Show navigation sidebar (default: false)
 	Headless  bool `yaml:"headless"` // Run without web UI, only API/webhooks/schedules
+
+	// PrerenderDiagrams enables server-side mermaid pre-rendering via
+	// Kroki. When true, ```mermaid blocks are converted to inline SVG at
+	// parse time and the ~3.3MB client-side mermaid runtime is skipped on
+	// pages where ALL blocks pre-rendered successfully. Blocks that fail
+	// to render fall back to the client-side runtime. Default: false.
+	PrerenderDiagrams bool `yaml:"prerender_diagrams,omitempty"`
+
+	// KrokiURL overrides the Kroki base URL used for diagram pre-render
+	// (default: https://kroki.io public instance). Point this at a
+	// self-hosted Kroki container for production deployments where the
+	// public instance's rate limits or terms are not acceptable.
+	KrokiURL string `yaml:"kroki_url,omitempty"`
 }
 
 // APIConfig holds REST API configuration

--- a/internal/diagrams/kroki.go
+++ b/internal/diagrams/kroki.go
@@ -1,0 +1,136 @@
+// Package diagrams provides server-side renderers for diagram-as-code
+// blocks (currently mermaid via Kroki) so tinkerdown sites can ship
+// pre-rendered SVGs and skip the heavyweight client-side runtime.
+//
+// The package exposes a small Renderer interface; the concrete Kroki
+// implementation talks to https://kroki.io by default but accepts any
+// Kroki-compatible URL (self-hosted instances are encouraged for
+// production use). Results are content-hash-cached in memory so each
+// unique source string costs at most one HTTP round-trip per process
+// lifetime.
+package diagrams
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Renderer renders a diagram source string (e.g. mermaid markup) to an
+// SVG byte slice. Implementations MUST return a non-nil error on
+// failure — callers use that as the signal to fall back to client-side
+// rendering rather than serving a blank or partial diagram.
+type Renderer interface {
+	Render(source []byte) ([]byte, error)
+}
+
+// KrokiRenderer talks to a Kroki HTTP service. The default base URL
+// targets the public instance at https://kroki.io which is rate-limited
+// but adequate for low-traffic sites whose unique-diagram count is
+// small (because cache hits skip the network entirely). For higher
+// traffic, point BaseURL at a self-hosted Kroki container.
+type KrokiRenderer struct {
+	BaseURL    string        // e.g. "https://kroki.io"
+	DiagramKey string        // Kroki diagram type, e.g. "mermaid"
+	Timeout    time.Duration // per-request timeout (default 5s)
+	HTTPClient *http.Client  // injectable for tests; nil → built from Timeout
+
+	mu    sync.RWMutex
+	cache map[string][]byte // key: sha256 of source; value: SVG bytes
+}
+
+// NewKrokiMermaid returns a KrokiRenderer pre-configured for mermaid.
+// baseURL may be empty to use the public https://kroki.io instance.
+func NewKrokiMermaid(baseURL string) *KrokiRenderer {
+	if baseURL == "" {
+		baseURL = "https://kroki.io"
+	}
+	return &KrokiRenderer{
+		BaseURL:    baseURL,
+		DiagramKey: "mermaid",
+		Timeout:    5 * time.Second,
+		cache:      make(map[string][]byte),
+	}
+}
+
+// Render returns the SVG bytes for the given mermaid source. Cache
+// hits (sha256-keyed) skip the network. On any HTTP error or non-2xx
+// response the source is NOT cached — transient failures get retried
+// on the next call.
+func (k *KrokiRenderer) Render(source []byte) ([]byte, error) {
+	key := hashKey(source)
+
+	k.mu.RLock()
+	if cached, ok := k.cache[key]; ok {
+		k.mu.RUnlock()
+		return cached, nil
+	}
+	k.mu.RUnlock()
+
+	svg, err := k.fetch(source)
+	if err != nil {
+		return nil, err
+	}
+
+	k.mu.Lock()
+	k.cache[key] = svg
+	k.mu.Unlock()
+
+	return svg, nil
+}
+
+// fetch performs the actual HTTP POST to Kroki. Kroki accepts the raw
+// diagram source as the request body; the URL determines the diagram
+// type and output format.
+func (k *KrokiRenderer) fetch(source []byte) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/svg", k.BaseURL, k.DiagramKey)
+
+	client := k.HTTPClient
+	if client == nil {
+		timeout := k.Timeout
+		if timeout == 0 {
+			timeout = 5 * time.Second
+		}
+		client = &http.Client{Timeout: timeout}
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(source))
+	if err != nil {
+		return nil, fmt.Errorf("kroki: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	req.Header.Set("Accept", "image/svg+xml")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("kroki: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("kroki: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Kroki returns a plain-text error body on syntax errors;
+		// surface enough of it to be diagnostic without flooding logs.
+		snippet := string(body)
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "…"
+		}
+		return nil, fmt.Errorf("kroki: status %d: %s", resp.StatusCode, snippet)
+	}
+
+	return body, nil
+}
+
+func hashKey(source []byte) string {
+	h := sha256.Sum256(source)
+	return hex.EncodeToString(h[:])
+}

--- a/internal/diagrams/kroki_test.go
+++ b/internal/diagrams/kroki_test.go
@@ -1,0 +1,141 @@
+package diagrams
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestKrokiRendersAndCachesByContentHash(t *testing.T) {
+	var hits int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mermaid/svg", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.WriteHeader(200)
+		// Echo the source back wrapped in fake SVG so tests can verify
+		// content flowed end-to-end.
+		w.Write([]byte("<svg>" + string(body) + "</svg>"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	r := NewKrokiMermaid(server.URL)
+
+	src := []byte("flowchart LR\n  A --> B\n")
+
+	// First call hits the server.
+	svg, err := r.Render(src)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(string(svg), "flowchart LR") {
+		t.Errorf("svg %q does not contain source", svg)
+	}
+
+	// Second call (same source) MUST be served from cache.
+	svg2, err := r.Render(src)
+	if err != nil {
+		t.Fatalf("Render (cached): %v", err)
+	}
+	if string(svg) != string(svg2) {
+		t.Errorf("cache returned different bytes")
+	}
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Errorf("hits = %d, want 1 (cache miss + 1 hit)", got)
+	}
+
+	// Different source MUST hit the server again.
+	if _, err := r.Render([]byte("different source")); err != nil {
+		t.Fatalf("Render (different): %v", err)
+	}
+	if got := atomic.LoadInt64(&hits); got != 2 {
+		t.Errorf("hits = %d, want 2", got)
+	}
+}
+
+func TestKrokiReturnsErrorOnNon200(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mermaid/svg", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte("syntax error: unrecognized token"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	r := NewKrokiMermaid(server.URL)
+	_, err := r.Render([]byte("not mermaid"))
+	if err == nil {
+		t.Fatal("expected error on 400 response")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should include status code: %v", err)
+	}
+}
+
+func TestKrokiDoesNotCacheFailures(t *testing.T) {
+	var hits int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mermaid/svg", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		// Fail first time, succeed after.
+		if atomic.LoadInt64(&hits) == 1 {
+			w.WriteHeader(503)
+			return
+		}
+		w.WriteHeader(200)
+		w.Write([]byte("<svg>ok</svg>"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	r := NewKrokiMermaid(server.URL)
+	src := []byte("flowchart LR\n  A --> B\n")
+
+	if _, err := r.Render(src); err == nil {
+		t.Fatal("first render should have errored")
+	}
+	// Retry MUST hit the server again, not return the cached error.
+	svg, err := r.Render(src)
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if !strings.Contains(string(svg), "ok") {
+		t.Errorf("expected successful response on retry, got %q", svg)
+	}
+	if got := atomic.LoadInt64(&hits); got != 2 {
+		t.Errorf("hits = %d, want 2 (retry should not be cached)", got)
+	}
+}
+
+func TestKrokiTimeoutHonored(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mermaid/svg", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Write([]byte("<svg>too late</svg>"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	r := NewKrokiMermaid(server.URL)
+	r.Timeout = 50 * time.Millisecond
+
+	if _, err := r.Render([]byte("source")); err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestKrokiDefaultsToPublicInstance(t *testing.T) {
+	r := NewKrokiMermaid("")
+	if r.BaseURL != "https://kroki.io" {
+		t.Errorf("default BaseURL = %q, want https://kroki.io", r.BaseURL)
+	}
+	if r.DiagramKey != "mermaid" {
+		t.Errorf("DiagramKey = %q, want mermaid", r.DiagramKey)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,9 +17,20 @@ import (
 	"github.com/livetemplate/tinkerdown"
 	"github.com/livetemplate/tinkerdown/internal/assets"
 	"github.com/livetemplate/tinkerdown/internal/config"
+	"github.com/livetemplate/tinkerdown/internal/diagrams"
 	"github.com/livetemplate/tinkerdown/internal/schedule"
 	"github.com/livetemplate/tinkerdown/internal/site"
 )
+
+// defaultStr returns s when non-empty, otherwise fallback. Local helper
+// for log lines where an empty config value should display as the
+// runtime-applied default.
+func defaultStr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
 
 // Route represents a discovered page route.
 type Route struct {
@@ -76,6 +87,15 @@ func NewWithConfig(rootDir string, cfg *config.Config) *Server {
 	// Initialize site manager if in site mode
 	if cfg.IsSiteMode() {
 		srv.siteManager = site.New(rootDir, cfg)
+	}
+
+	// Wire up server-side diagram pre-rendering (G16) when enabled. Done
+	// BEFORE Discover() so the parser sees the renderer on first parse.
+	// Setter is idempotent — re-init or hot-reload paths can call again.
+	if cfg.Features.PrerenderDiagrams {
+		tinkerdown.SetMermaidRenderer(diagrams.NewKrokiMermaid(cfg.Features.KrokiURL))
+		log.Printf("[Diagrams] mermaid pre-render enabled (Kroki=%s)",
+			defaultStr(cfg.Features.KrokiURL, "https://kroki.io"))
 	}
 
 	// Build reverse-proxy routes from config. Bad entries are logged but

--- a/parser.go
+++ b/parser.go
@@ -238,6 +238,16 @@ func ParseMarkdown(content []byte) (*Frontmatter, []*CodeBlock, string, error) {
 		frontmatter.HasCharts = true
 	}
 
+	// Pre-render mermaid blocks to inline SVG when a renderer is registered
+	// (server enables this via SetMermaidRenderer at startup based on
+	// features.prerender_diagrams). Re-set HasMermaid based on blocks that
+	// the renderer COULD NOT handle — only those still need the runtime.
+	if frontmatter.HasMermaid {
+		var remainingMermaid int
+		html, remainingMermaid = processMermaid(html, mermaidRenderer)
+		frontmatter.HasMermaid = remainingMermaid > 0
+	}
+
 	// Parse schedule tokens and imperatives from markdown content
 	schedules, scheduleWarnings := parseScheduleTokens(remaining)
 	if len(schedules) > 0 {
@@ -695,6 +705,83 @@ var htmlTagPattern = regexp.MustCompile(`<[^>]*>`)
 var chartAnnotationPattern = regexp.MustCompile(
 	`(<h([1-6])\s+id="[^"]*"[^>]*>)(.*?)\s*\{chart(?::(\w+))?\}\s*(</h[1-6]>)`,
 )
+
+// mermaidBlockPattern matches goldmark-rendered ```mermaid fenced blocks:
+//
+//	<pre><code class="language-mermaid">…source…</code></pre>
+//
+// The `(?s)` flag lets `.` cross newlines so multi-line diagram source matches.
+// Capture group 1 is the diagram source (HTML-escaped — caller must unescape
+// before sending to a renderer).
+var mermaidBlockPattern = regexp.MustCompile(
+	`(?s)<pre><code class="language-mermaid">(.*?)</code></pre>`,
+)
+
+// mermaidRenderer is the package-level diagram renderer used by parsing
+// when set. Servers initialize this once at startup based on config; nil
+// means "no pre-rendering, leave mermaid blocks for the client runtime".
+//
+// Made package-level (rather than threaded through every parse function)
+// to avoid breaking the existing ParseMarkdown / ParseFile API surface.
+var mermaidRenderer DiagramRenderer
+
+// DiagramRenderer renders diagram source to bytes (typically inline SVG).
+// The interface deliberately mirrors internal/diagrams.Renderer so the
+// concrete implementation can live in that subpackage without forcing
+// callers of tinkerdown to import it.
+type DiagramRenderer interface {
+	Render(source []byte) ([]byte, error)
+}
+
+// SetMermaidRenderer registers a renderer that will be used to pre-render
+// ```mermaid fenced blocks during ParseMarkdown. Pass nil to disable.
+// Safe to call once during server initialization.
+func SetMermaidRenderer(r DiagramRenderer) {
+	mermaidRenderer = r
+}
+
+// processMermaid replaces ```mermaid fenced blocks with inline SVG when a
+// renderer is available. Blocks that fail to render are left intact so the
+// client-side runtime can handle them — this is the graceful-degradation
+// path that keeps pages working when Kroki is unreachable.
+//
+// Returns the modified HTML and the number of blocks that were NOT
+// pre-rendered (i.e. still need the client-side runtime). Callers use the
+// remaining count to decide whether to inject the mermaid runtime script.
+func processMermaid(htmlStr string, renderer DiagramRenderer) (string, int) {
+	matches := mermaidBlockPattern.FindAllStringSubmatchIndex(htmlStr, -1)
+	if len(matches) == 0 {
+		return htmlStr, 0
+	}
+	if renderer == nil {
+		return htmlStr, len(matches)
+	}
+
+	remaining := 0
+	// Walk in reverse so indices stay valid as we splice replacements in.
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		blockStart, blockEnd := m[0], m[1]
+		sourceStart, sourceEnd := m[2], m[3]
+
+		// Goldmark HTML-escapes the code-block contents (e.g. `>` → `&gt;`).
+		// Kroki expects the original mermaid syntax, so unescape first.
+		source := html.UnescapeString(htmlStr[sourceStart:sourceEnd])
+
+		svg, err := renderer.Render([]byte(source))
+		if err != nil {
+			// Keep the block — client runtime will render it.
+			remaining++
+			continue
+		}
+
+		// Wrap in a div so themes / dark mode CSS can target pre-rendered
+		// diagrams distinctly from runtime-rendered ones.
+		replacement := `<div class="mermaid-prerendered">` + string(svg) + `</div>`
+		htmlStr = htmlStr[:blockStart] + replacement + htmlStr[blockEnd:]
+	}
+	return htmlStr, remaining
+}
 
 // chartTablePattern matches a GFM-rendered table immediately after a heading.
 // Uses <table[^>]*> to tolerate attributes Goldmark may add via extensions.
@@ -1177,6 +1264,13 @@ func ParseMarkdownWithPartials(content []byte, baseDir string) (*Frontmatter, []
 	htmlStr, hasCharts := processCharts(htmlStr, frontmatter.Charts)
 	if hasCharts {
 		frontmatter.HasCharts = true
+	}
+
+	// Pre-render mermaid (see ParseMarkdown for rationale).
+	if frontmatter.HasMermaid {
+		var remainingMermaid int
+		htmlStr, remainingMermaid = processMermaid(htmlStr, mermaidRenderer)
+		frontmatter.HasMermaid = remainingMermaid > 0
 	}
 
 	// Parse schedule tokens and imperatives from markdown content

--- a/parser_test.go
+++ b/parser_test.go
@@ -1037,6 +1037,154 @@ func TestProcessCharts(t *testing.T) {
 	}
 }
 
+// stubRenderer is a controllable DiagramRenderer for tests.
+type stubRenderer struct {
+	output []byte
+	err    error
+}
+
+func (s stubRenderer) Render(_ []byte) ([]byte, error) {
+	return s.output, s.err
+}
+
+// captureRenderer records the source bytes passed to Render so tests
+// can verify the unescape contract.
+type captureRenderer struct {
+	ref    *[]byte
+	output []byte
+}
+
+func (c captureRenderer) Render(source []byte) ([]byte, error) {
+	*c.ref = append([]byte{}, source...)
+	return c.output, nil
+}
+
+type errStubT string
+
+func (e errStubT) Error() string { return string(e) }
+
+var errStub = errStubT("renderer down for test")
+
+func TestProcessMermaidNoOpWithoutRenderer(t *testing.T) {
+	in := `<p>before</p><pre><code class="language-mermaid">flowchart LR
+  A --&gt; B
+</code></pre><p>after</p>`
+	out, remaining := processMermaid(in, nil)
+	if out != in {
+		t.Errorf("html should be unchanged when renderer is nil")
+	}
+	if remaining != 1 {
+		t.Errorf("remaining = %d, want 1", remaining)
+	}
+}
+
+func TestProcessMermaidReplacesBlockOnSuccess(t *testing.T) {
+	in := `<pre><code class="language-mermaid">flowchart LR
+  A --&gt; B
+</code></pre>`
+	r := stubRenderer{output: []byte(`<svg>diagram</svg>`)}
+	out, remaining := processMermaid(in, r)
+
+	if remaining != 0 {
+		t.Errorf("remaining = %d, want 0", remaining)
+	}
+	if !strings.Contains(out, `<div class="mermaid-prerendered"><svg>diagram</svg></div>`) {
+		t.Errorf("expected pre-rendered div in output: %s", out)
+	}
+	if strings.Contains(out, "language-mermaid") {
+		t.Errorf("original block should be removed: %s", out)
+	}
+}
+
+func TestProcessMermaidLeavesBlockOnRendererError(t *testing.T) {
+	in := `<pre><code class="language-mermaid">bad source</code></pre>`
+	r := stubRenderer{err: errStub}
+	out, remaining := processMermaid(in, r)
+
+	if remaining != 1 {
+		t.Errorf("remaining = %d, want 1 (failure should keep the block)", remaining)
+	}
+	if !strings.Contains(out, "language-mermaid") {
+		t.Errorf("failed-render block should remain in output: %s", out)
+	}
+	if strings.Contains(out, "mermaid-prerendered") {
+		t.Errorf("no pre-rendered div should be emitted on failure: %s", out)
+	}
+}
+
+func TestProcessMermaidUnescapesSourceBeforeRendering(t *testing.T) {
+	// Goldmark HTML-escapes < and > inside fenced blocks. The renderer
+	// must receive the original mermaid syntax, not the escaped form.
+	in := `<pre><code class="language-mermaid">flowchart LR
+  A --&gt; B
+  B --&lt; C
+</code></pre>`
+	var captured []byte
+	r := captureRenderer{ref: &captured, output: []byte("<svg/>")}
+	processMermaid(in, r)
+
+	if !strings.Contains(string(captured), "-->") {
+		t.Errorf("renderer received escaped HTML instead of raw mermaid: %q", captured)
+	}
+	if strings.Contains(string(captured), "&gt;") {
+		t.Errorf("renderer received escaped &gt;: %q", captured)
+	}
+}
+
+func TestProcessMermaidHandlesMultipleBlocks(t *testing.T) {
+	in := `<pre><code class="language-mermaid">A</code></pre>
+<p>between</p>
+<pre><code class="language-mermaid">B</code></pre>`
+	r := stubRenderer{output: []byte("<svg/>")}
+	out, remaining := processMermaid(in, r)
+
+	if remaining != 0 {
+		t.Errorf("remaining = %d, want 0", remaining)
+	}
+	if strings.Count(out, "mermaid-prerendered") != 2 {
+		t.Errorf("expected 2 pre-rendered divs, got: %s", out)
+	}
+}
+
+func TestParseMarkdownEndToEndPreRendersWhenRendererSet(t *testing.T) {
+	r := stubRenderer{output: []byte(`<svg id="diag">x</svg>`)}
+	SetMermaidRenderer(r)
+	t.Cleanup(func() { SetMermaidRenderer(nil) })
+
+	content := []byte("---\ntitle: Diag\n---\n\n```mermaid\nflowchart LR\n  A --> B\n```\n")
+	fm, _, html, err := ParseMarkdown(content)
+	if err != nil {
+		t.Fatalf("ParseMarkdown: %v", err)
+	}
+	if fm.HasMermaid {
+		t.Error("HasMermaid should be false when ALL blocks pre-rendered (skips runtime injection)")
+	}
+	if !strings.Contains(html, `mermaid-prerendered`) {
+		t.Errorf("html missing pre-rendered marker: %s", html)
+	}
+	if strings.Contains(html, "language-mermaid") {
+		t.Errorf("original mermaid block should be replaced: %s", html)
+	}
+}
+
+func TestParseMarkdownEndToEndKeepsBlockOnRendererFailure(t *testing.T) {
+	r := stubRenderer{err: errStub}
+	SetMermaidRenderer(r)
+	t.Cleanup(func() { SetMermaidRenderer(nil) })
+
+	content := []byte("---\ntitle: Diag\n---\n\n```mermaid\nflowchart LR\n  A --> B\n```\n")
+	fm, _, html, err := ParseMarkdown(content)
+	if err != nil {
+		t.Fatalf("ParseMarkdown: %v", err)
+	}
+	if !fm.HasMermaid {
+		t.Error("HasMermaid should remain true when renderer fails (runtime needed for fallback)")
+	}
+	if !strings.Contains(html, "language-mermaid") {
+		t.Errorf("original block must remain for client-side fallback: %s", html)
+	}
+}
+
 func TestParseMarkdownDetectsMermaid(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
## Summary
Adds opt-in server-side mermaid pre-rendering via Kroki, closing G16 from the docs site (Lighthouse perf 55 on diagram pages). When enabled, \`\`\`mermaid blocks are converted to inline SVG at parse time and the ~3.3MB client-side mermaid runtime is skipped on pages where all blocks pre-rendered successfully.

## Why this exists
Despite v0.1.2's \`defer\` + conditional-load fix, mermaid pages still scored Lighthouse perf 55 because the dominant cost is **TBT (parsing/executing 3.3MB of JS on the main thread)**, not load time. \`defer\` doesn't help with that. The only fix that moves the score is to skip the runtime entirely.

## Design
- New \`internal/diagrams\` package: \`Renderer\` interface + Kroki HTTP impl with sha256 cache.
- New parser-level \`processMermaid\` (mirrors \`processCharts\`): regex-find ` + "`" + `` + "`" + `` + "`" + `mermaid blocks, unescape goldmark's HTML-encoding, hand to the renderer, replace with \`<div class="mermaid-prerendered">SVG</div>\`. Failed blocks are LEFT INTACT — the client runtime still picks them up. Failure mode is graceful degradation, not blank diagrams.
- \`Page.HasMermaid\` re-set after the pass to count only blocks that did NOT pre-render. Server skips the runtime injection when zero remain.
- Opt-in via \`features.prerender_diagrams\` (default false). Optional \`features.kroki_url\` for self-hosted Kroki.
- Package-level \`SetMermaidRenderer\` setter (avoids threading a renderer through every parse call site; mirrors \`http.DefaultTransport\` style).

## Test plan
- [x] 5 Kroki client tests (httptest stub): cache by content hash, error on non-200, failures NOT cached (transient errors retry), timeout honored, default-instance constant
- [x] 5 \`processMermaid\` tests: no-op without renderer; block replacement on success; block preservation on error; HTML-unescape contract; multi-block
- [x] 2 ParseMarkdown end-to-end tests: HasMermaid flips false on full success; stays true on renderer failure
- [x] Real Kroki round-trip against the docs-site architecture-flow recipe — produces 1681×585 SVG ✓
- [ ] Will be re-verified end-to-end with Lighthouse against livetemplate.fly.dev after merge + tag + Dockerfile pin + redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)