### PR TITLE
fix(diagrams): pre-rendered div uses both mermaid + mermaid-prerendered classes

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -775,9 +775,12 @@ func processMermaid(htmlStr string, renderer DiagramRenderer) (string, int) {
 			continue
 		}
 
-		// Wrap in a div so themes / dark mode CSS can target pre-rendered
-		// diagrams distinctly from runtime-rendered ones.
-		replacement := `<div class="mermaid-prerendered">` + string(svg) + `</div>`
+		// Wrap in a div with BOTH classes: `mermaid` (the canonical
+		// container class used by the client-side runtime, so existing
+		// CSS / e2e selectors keep matching) and `mermaid-prerendered`
+		// (so themes that need to distinguish pre-rendered from
+		// runtime-rendered diagrams still can).
+		replacement := `<div class="mermaid mermaid-prerendered">` + string(svg) + `</div>`
 		htmlStr = htmlStr[:blockStart] + replacement + htmlStr[blockEnd:]
 	}
 	return htmlStr, remaining

--- a/parser_test.go
+++ b/parser_test.go
@@ -1088,7 +1088,7 @@ func TestProcessMermaidReplacesBlockOnSuccess(t *testing.T) {
 	if remaining != 0 {
 		t.Errorf("remaining = %d, want 0", remaining)
 	}
-	if !strings.Contains(out, `<div class="mermaid-prerendered"><svg>diagram</svg></div>`) {
+	if !strings.Contains(out, `<div class="mermaid mermaid-prerendered"><svg>diagram</svg></div>`) {
 		t.Errorf("expected pre-rendered div in output: %s", out)
 	}
 	if strings.Contains(out, "language-mermaid") {


### PR DESCRIPTION
Small follow-up to #234. The pre-render PR only set `class="mermaid-prerendered"` on the inline-SVG container. Existing CSS / e2e selectors targeting `.mermaid` (the canonical container class used by the client-side runtime) stopped matching — broke 4 docs-site e2e tests that poll for `.mermaid svg`.

Adding both classes preserves backward compatibility while keeping `.mermaid-prerendered` for theming hooks that need to distinguish pre-rendered SVGs from runtime-converted ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)