### PR TITLE
fix(server): responsive sidebar — desktop layout + mobile hamburger

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1689,9 +1689,50 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
         }
 
         .nav-pages {
+            /* Override PicoCSS nav ul { display: flex } which would otherwise
+             * lay out nav items horizontally and crush them in the sidebar. */
+            display: block;
             list-style: none;
             margin: 0;
             padding: 0;
+        }
+
+        /* Mobile navigation toggle. Hidden on desktop; appears at <=768px
+         * to expose the otherwise-translated-off-screen sidebar. */
+        .tinkerdown-nav-toggle {
+            display: none;
+            position: fixed;
+            top: 0.75rem;
+            left: 0.75rem;
+            z-index: 1100;
+            background: var(--card-bg);
+            color: var(--text-primary);
+            border: 1px solid var(--card-border);
+            border-radius: 6px;
+            padding: 0.5rem;
+            cursor: pointer;
+            box-shadow: 0 2px 4px var(--card-shadow);
+            align-items: center;
+            justify-content: center;
+        }
+        .tinkerdown-nav-toggle:hover {
+            background: var(--bg-secondary);
+        }
+        .tinkerdown-nav-toggle svg {
+            display: block;
+        }
+
+        /* Backdrop shown behind the open sidebar on mobile so taps outside
+         * the menu close it. Click handler attached in the toggle script. */
+        .tinkerdown-nav-backdrop {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.4);
+            z-index: 850;
+        }
+        .tinkerdown-nav-backdrop.open {
+            display: block;
         }
 
         .nav-pages li a {
@@ -1948,13 +1989,21 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
                 transform: translateX(0);
             }
 
+            /* Reveal the toggle button at mobile widths. */
+            .tinkerdown-nav-toggle {
+                display: flex;
+            }
+
+            /* Make room for the fixed-position toggle so it doesn't overlap
+             * the page H1. Only applied when a sidebar exists. */
+            body:has(.tinkerdown-nav-sidebar) {
+                margin-left: 0;
+                padding-top: 3.5rem;
+            }
+
             .tinkerdown-nav-bottom {
                 left: 0;
                 padding: 0 1rem;
-            }
-
-            body:has(.tinkerdown-nav-sidebar) {
-                margin-left: 0;
             }
 
             .nav-btn {
@@ -2909,7 +2958,15 @@ func (s *Server) renderSidebar(currentPath string) string {
 	}
 
 	var html strings.Builder
-	html.WriteString(`<nav class="tinkerdown-nav-sidebar">`)
+
+	// Mobile hamburger toggle + backdrop. Hidden on desktop via CSS; on
+	// mobile the hamburger is fixed top-left and the backdrop covers the
+	// page when the sidebar is open. Inline SVG keeps the bundle CSP-clean
+	// (no font-icon library, no external image fetch).
+	html.WriteString(`<button type="button" class="tinkerdown-nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="tinkerdown-sidebar"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button>`)
+	html.WriteString(`<div class="tinkerdown-nav-backdrop" aria-hidden="true"></div>`)
+
+	html.WriteString(`<nav id="tinkerdown-sidebar" class="tinkerdown-nav-sidebar">`)
 
 	// Site title/logo
 	if s.config.Site != nil && s.config.Title != "" {
@@ -2937,6 +2994,35 @@ func (s *Server) renderSidebar(currentPath string) string {
 	}
 
 	html.WriteString(`</nav>`)
+
+	// Toggle wiring. Idempotent re-init guard so hot-reload / re-mounted
+	// scripts don't double-bind handlers. CSP-friendly (no inline event
+	// attributes — only event listeners on a single inline script).
+	html.WriteString(`<script>(function(){
+		var toggle = document.querySelector('.tinkerdown-nav-toggle');
+		var sidebar = document.querySelector('.tinkerdown-nav-sidebar');
+		var backdrop = document.querySelector('.tinkerdown-nav-backdrop');
+		if (!toggle || !sidebar || toggle.dataset.bound === '1') return;
+		toggle.dataset.bound = '1';
+		function setOpen(open) {
+			sidebar.classList.toggle('open', open);
+			if (backdrop) backdrop.classList.toggle('open', open);
+			toggle.setAttribute('aria-expanded', String(open));
+		}
+		toggle.addEventListener('click', function() {
+			setOpen(!sidebar.classList.contains('open'));
+		});
+		if (backdrop) backdrop.addEventListener('click', function() { setOpen(false); });
+		// Close when a nav link is tapped — mobile UX expectation.
+		sidebar.addEventListener('click', function(e) {
+			if (e.target && e.target.closest && e.target.closest('a')) setOpen(false);
+		});
+		// Close on Escape key.
+		document.addEventListener('keydown', function(e) {
+			if (e.key === 'Escape' && sidebar.classList.contains('open')) setOpen(false);
+		});
+	})();</script>`)
+
 	return html.String()
 }
 

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+// Regression: G16-era + responsive-sidebar fix.
+//
+// Two long-standing layout bugs were caught after launch by visual
+// inspection of livetemplate.fly.dev and locked in here:
+//
+//  1. .nav-pages didn't override PicoCSS's `nav ul { display: flex }`,
+//     so sidebar items rendered horizontally (cramped, truncated).
+//  2. Mobile breakpoint hid the sidebar with translateX(-100%) but
+//     emitted no hamburger button — the sidebar was unreachable.
+//
+// These tests fail if a future change reintroduces either bug.
+
+func TestSidebarOverridesPicoFlex(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+	idx := strings.Index(body, ".nav-pages {")
+	if idx < 0 {
+		t.Fatal(".nav-pages CSS rule missing")
+	}
+	// The rule comment contains `}` so a naive close-brace scan cuts off
+	// too early. Instead just check the next ~500 chars after the rule
+	// opens for the explicit display override. Without it, PicoCSS's
+	// `nav ul { display: flex }` cascades through and re-introduces
+	// the cramped-horizontal-sidebar bug.
+	window := body[idx:]
+	if len(window) > 500 {
+		window = window[:500]
+	}
+	if !strings.Contains(window, "display: block") {
+		t.Errorf(".nav-pages must declare `display: block` to override PicoCSS nav-ul flex; first 500 chars after .nav-pages:\n%s", window)
+	}
+}
+
+func TestSidebarRendersMobileToggleAndBackdrop(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+
+	if !strings.Contains(body, `class="tinkerdown-nav-toggle"`) {
+		t.Error("hamburger toggle button missing — mobile users have no way to open the sidebar")
+	}
+	if !strings.Contains(body, `aria-label="Toggle navigation"`) {
+		t.Error("hamburger button missing aria-label (a11y regression)")
+	}
+	if !strings.Contains(body, `aria-controls="tinkerdown-sidebar"`) {
+		t.Error("hamburger missing aria-controls — assistive tech can't link button → menu")
+	}
+	if !strings.Contains(body, `class="tinkerdown-nav-backdrop"`) {
+		t.Error("backdrop element missing — mobile users can't tap-outside to close")
+	}
+
+	// CSS must hide the toggle by default (desktop) and reveal it under
+	// the mobile media query.
+	if !strings.Contains(body, ".tinkerdown-nav-toggle {\n            display: none;") {
+		t.Error(".tinkerdown-nav-toggle should default to display: none (hidden on desktop)")
+	}
+	// The page emits multiple `@media (max-width: 768px)` rules (one per
+	// component). Rather than parse them all, just assert the
+	// toggle-flips-to-flex rule exists anywhere in the document. The
+	// rule body the responsive fix introduces:
+	//
+	//     .tinkerdown-nav-toggle {
+	//         display: flex;
+	//     }
+	if !strings.Contains(body, ".tinkerdown-nav-toggle {\n                display: flex;") {
+		t.Error("mobile breakpoint must flip toggle to display: flex (regression: sidebar unreachable on mobile)")
+	}
+}
+
+func TestSidebarToggleScriptIsBound(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+	// The inline toggle script needs to be present and use the
+	// double-bind guard so hot-reload doesn't double-wire handlers.
+	if !strings.Contains(body, "toggle.dataset.bound") {
+		t.Error("toggle JS should set/check dataset.bound to avoid double-binding on re-render")
+	}
+	if !strings.Contains(body, "Escape") {
+		t.Error("toggle JS should close the sidebar on Escape (a11y / UX expectation)")
+	}
+}
+
+// renderHomeWithSidebar boots a tiny in-memory site, hits /, and returns
+// the rendered HTML body.
+func renderHomeWithSidebar(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "home.md"), []byte("---\ntitle: Home\n---\n# Home\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Title = "Test Docs"
+	cfg.Site = &config.SiteConfig{Home: "home.md"}
+	cfg.Features.Sidebar = true
+	cfg.Navigation = []config.NavSection{{
+		Title: "Top",
+		Pages: []config.NavPage{{Title: "Home", Path: "home.md"}},
+	}}
+
+	srv := NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/home", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+


### PR DESCRIPTION
## Summary

Two layout bugs caught by visual inspection of livetemplate.fly.dev after launch:

**Desktop**: \`.nav-pages\` computed \`display: flex; flex-direction: row\` because PicoCSS's \`nav ul { display: flex }\` cascaded through unopposed (the rule declared list-style / margin / padding but never overrode \`display\`). Sidebar nav items rendered horizontally — cramped and visually broken.

**Mobile**: existing CSS hid the sidebar with \`transform: translateX(-100%)\` and a comment saying "show hamburger menu" but no hamburger was actually rendered. Sidebar unreachable on phones.

## Fix

1. \`.nav-pages { display: block }\` — one line, classic specificity gotcha
2. Hamburger button + backdrop rendered in \`renderSidebar\`, default \`display: none\`, switched to \`display: flex\` at the \`@media (max-width: 768px)\` breakpoint. Inline JS handles click / backdrop-tap / Escape / link-tap close. Idempotent \`dataset.bound\` guard prevents double-binding.

CSP-clean: only addEventListener-based handlers, no inline event attrs.

## Test plan

- [x] 3 new regression tests in \`sidebar_responsive_test.go\` lock both bugs:
  - \`.nav-pages\` declares \`display: block\` within first 500 chars after the rule
  - hamburger button + backdrop + ARIA attrs all rendered
  - mobile breakpoint flips toggle to \`display: flex\`
  - toggle JS uses dataset.bound guard + Escape handler
- [x] Full \`internal/server/\` test suite green
- [ ] Will be re-verified end-to-end via responsive screenshot diff against prod after merge + tag + Dockerfile pin + redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)