### PR TITLE
fix(server): sidebar nav LI must override PicoCSS inline-block

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1697,6 +1697,17 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             padding: 0;
         }
 
+        .nav-pages li {
+            /* Override PicoCSS nav li { display: inline-block }. The previous
+             * fix on .nav-pages only switched the UL to block; PicoCSS still
+             * laid out the LIs as inline-block at ~135px each, so they
+             * packed horizontally in the sidebar. Force list-item layout. */
+            display: list-item;
+            margin: 0;
+            padding: 0;
+            width: auto;
+        }
+
         /* Mobile navigation toggle. Hidden on desktop; appears at <=768px
          * to expose the otherwise-translated-off-screen sidebar. */
         .tinkerdown-nav-toggle {

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -43,6 +43,26 @@ func TestSidebarOverridesPicoFlex(t *testing.T) {
 	}
 }
 
+// PicoCSS sets `nav li { display: inline-block }` to lay out top-nav
+// items horizontally. The first sidebar fix overrode the UL but not
+// the LI, so list items continued packing inline-block in the sidebar
+// (~135px wide each, two-or-three short titles still fit on one line).
+// This locks the second-level override.
+func TestSidebarLiIsListItem(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+	idx := strings.Index(body, ".nav-pages li {")
+	if idx < 0 {
+		t.Fatal(".nav-pages li CSS rule missing — without it, PicoCSS lays out items as inline-block")
+	}
+	window := body[idx:]
+	if len(window) > 500 {
+		window = window[:500]
+	}
+	if !strings.Contains(window, "display: list-item") && !strings.Contains(window, "display: block") {
+		t.Errorf(".nav-pages li must override PicoCSS's display: inline-block (use list-item or block); rule window:\n%s", window)
+	}
+}
+
 func TestSidebarRendersMobileToggleAndBackdrop(t *testing.T) {
 	body := renderHomeWithSidebar(t)
 


### PR DESCRIPTION
Follow-up to #236. The previous fix only overrode the UL — PicoCSS's `nav li { display: inline-block }` still applied to children, so short-titled items continued packing horizontally. `.nav-pages li { display: list-item; width: auto }` completes the override.

Caught by post-deploy DOM inspection: `getComputedStyle(li).display = 'inline-block'` despite the UL fix. Regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)