### PR TITLE
fix(server): pre-rendered mermaid SVGs must be responsive

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1245,6 +1245,31 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             height: auto !important;
         }
 
+        /* Pre-rendered mermaid SVGs (G16) come back from Kroki at native
+         * pixel dimensions (e.g. 1681×585 for sequence diagrams). Without
+         * a responsive constraint they overflow mobile viewports and
+         * iOS Safari auto-scales the WHOLE PAGE down to fit, making text
+         * + the hamburger button appear squeezed. Force the SVG to scale
+         * down to its container; container itself allows horizontal scroll
+         * as a fallback for diagrams too detailed to readably scale. */
+        .mermaid-prerendered {
+            margin: 1.25rem 0;
+            max-width: 100%%;
+            overflow-x: auto;
+        }
+        .mermaid-prerendered svg {
+            display: block;
+            max-width: 100%%;
+            height: auto;
+        }
+        /* Same defensive sizing for runtime-rendered .mermaid containers
+         * (Mermaid 11+ honors useMaxWidth, but pin it explicitly so any
+         * overflow path is covered). */
+        .mermaid > svg {
+            max-width: 100%%;
+            height: auto;
+        }
+
         .tinkerdown-chart-table {
             margin: 0.5rem 0 1.5rem;
             font-size: 0.875rem;

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -97,6 +97,31 @@ func TestSidebarRendersMobileToggleAndBackdrop(t *testing.T) {
 	}
 }
 
+// G16 sub-issue: pre-rendered mermaid SVGs come back from Kroki at native
+// pixel dimensions (e.g. 1681×585 for sequence diagrams). Without
+// `max-width: 100%; height: auto` on the SVG, mobile Safari forces a
+// horizontal scrollbar and auto-scales the whole page down to fit —
+// making text appear squeezed at ~55% width and the hamburger button
+// shrink to invisibility. Lock the responsive constraint.
+func TestPrerenderedMermaidIsResponsive(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+
+	idx := strings.Index(body, ".mermaid-prerendered svg {")
+	if idx < 0 {
+		t.Fatal(".mermaid-prerendered svg CSS rule missing — diagrams will overflow mobile viewports")
+	}
+	window := body[idx:]
+	if len(window) > 300 {
+		window = window[:300]
+	}
+	if !strings.Contains(window, "max-width: 100%") {
+		t.Errorf(".mermaid-prerendered svg must declare max-width: 100%% to fit narrow viewports; rule:\n%s", window)
+	}
+	if !strings.Contains(window, "height: auto") {
+		t.Errorf(".mermaid-prerendered svg must declare height: auto so scaling stays proportional; rule:\n%s", window)
+	}
+}
+
 func TestSidebarToggleScriptIsBound(t *testing.T) {
 	body := renderHomeWithSidebar(t)
 	// The inline toggle script needs to be present and use the


### PR DESCRIPTION
G16 (Kroki pre-render) skipped a critical detail: the returned SVGs have native pixel dimensions (e.g. 1681×585 for sequence diagrams) that overflow mobile viewports. Without `max-width: 100%; height: auto` on the SVG, iOS Safari forces horizontal overflow and auto-scales the **whole page** down to fit — text appeared squeezed at ~55% width and the hamburger button shrank to invisibility.

Caught by a real iPhone screenshot from the user. chromedp at 393×852 didn't reproduce because its overflow handling differs from iOS Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)