### PR TITLE
fix(server): mobile no longer scrolls horizontally on pages with pre/tables

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1197,8 +1197,8 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             padding: 1.25rem 1rem;
             border-radius: 8px;
             overflow-x: auto;
-            margin: 1.5rem calc((800px - 100%%) / 2 * -1);
-            max-width: 1000px;
+            margin: 1.5rem 0;
+            max-width: 100%%;
             box-shadow: 0 4px 12px rgba(0,0,0,0.15);
             border: 1px solid var(--border-color);
         }
@@ -1210,17 +1210,43 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             color: inherit;
         }
 
+        /* Wide tables on narrow viewports get a horizontal scroll
+         * container instead of overflowing the page. display: block on
+         * the table preserves table-internal cell layout while letting
+         * the table itself scroll within the article column. */
+        article table {
+            display: block;
+            max-width: 100%%;
+            overflow-x: auto;
+        }
+
         /* Interactive blocks */
         .tinkerdown-wasm-block,
         .tinkerdown-interactive-block {
-            margin: 2rem calc((800px - 100%%) / 2 * -1);
-            max-width: 1000px;
+            margin: 2rem 0;
+            max-width: 100%%;
             padding: 1.5rem;
             background: var(--card-bg);
             border-radius: 16px;
             box-shadow: 0 4px 16px var(--card-shadow);
             border: 1px solid var(--card-border);
             transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        /* Bleed pre + interactive blocks beyond the article column on
+         * wide screens for visual emphasis. The article column maxes
+         * at 800px, so this trick is safe only when the viewport
+         * itself is wide enough that the negative margin doesn't pull
+         * the box past the viewport edge — below this breakpoint the
+         * blocks fit within the article column instead. */
+        @media (min-width: 900px) {
+            pre,
+            .tinkerdown-wasm-block,
+            .tinkerdown-interactive-block {
+                margin-left: calc((800px - 100%%) / 2 * -1);
+                margin-right: calc((800px - 100%%) / 2 * -1);
+                max-width: 1000px;
+            }
         }
 
         .tinkerdown-wasm-block:hover,

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -156,6 +156,67 @@ func TestPrerenderedMermaidIsResponsive(t *testing.T) {
 	}
 }
 
+// Regression: <pre> code blocks and interactive blocks used a negative
+// margin (margin: 1.5rem calc((800px - 100%) / 2 * -1)) to bleed past
+// the article column on desktop. On mobile (393px viewport) the
+// expression evaluates to ~-203px, pulling each block ~407px wider than
+// the viewport and forcing the entire page into horizontal overflow.
+// The fix moves the bleed-out trick behind a min-width media query so
+// it only applies when the viewport is wide enough to absorb it.
+func TestPreBleedOutGuardedByMediaQuery(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+
+	// The base `pre {` rule must NOT declare the negative-margin
+	// expression — that's the bug.
+	rest := body
+	for {
+		idx := strings.Index(rest, "pre {")
+		if idx < 0 {
+			break
+		}
+		end := strings.Index(rest[idx:], "}")
+		if end < 0 {
+			break
+		}
+		ruleBody := rest[idx : idx+end]
+		if strings.Contains(ruleBody, "(800px - 100%) / 2 * -1") {
+			t.Errorf("base `pre` rule declares negative-margin bleed-out — overflows mobile viewports:\n%s", ruleBody)
+		}
+		rest = rest[idx+end:]
+	}
+
+	// The bleed-out IS allowed inside an @media (min-width: 900px) block.
+	if !strings.Contains(body, "@media (min-width: 900px)") {
+		t.Error("pre/wasm-block bleed-out must live inside @media (min-width: 900px) — guarantees no mobile overflow")
+	}
+	if !strings.Contains(body, "calc((800px - 100%) / 2 * -1)") {
+		t.Error("desktop bleed-out math (calc((800px - 100%) / 2 * -1)) should still exist inside the media query")
+	}
+}
+
+// Regression: wide reference tables (e.g. /reference/template-support-matrix)
+// have many columns whose combined intrinsic width exceeds the article
+// column on mobile. Without `display: block; overflow-x: auto;` on
+// `article table`, the table forces the document to scroll horizontally.
+func TestArticleTablesAreScrollable(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+
+	idx := strings.Index(body, "article table {")
+	if idx < 0 {
+		t.Fatal("article table rule missing — wide tables will force horizontal page overflow on mobile")
+	}
+	window := body[idx:]
+	if len(window) > 300 {
+		window = window[:300]
+	}
+	if !strings.Contains(window, "display: block") {
+		t.Errorf("article table must declare display: block so it can scroll independently; rule:\n%s", window)
+	}
+	if !strings.Contains(window, "overflow-x: auto") {
+		t.Errorf("article table must declare overflow-x: auto; rule:\n%s", window)
+	}
+}
+
 func TestSidebarToggleScriptIsBound(t *testing.T) {
 	body := renderHomeWithSidebar(t)
 	// The inline toggle script needs to be present and use the


### PR DESCRIPTION
## Summary

- A new sitemap-driven sweep harness in `livetemplate/docs` flagged **17 of 46 pages** with horizontal overflow on a 393px (iPhone 14) viewport.
- Root cause: the base `pre` and `.tinkerdown-wasm-block`/`.tinkerdown-interactive-block` rules use `margin: ... calc((800px - 100%) / 2 * -1)` to visually bleed past the 800px article column on desktop. On a narrow viewport the expression evaluates to roughly **-203px**, pulling each block ~407px wider than its parent and pushing the entire document into horizontal overflow.
- Secondary bug: wide reference tables (e.g. `template-support-matrix`) had no scroll container.

## Fix

* Move the negative-margin bleed-out trick behind `@media (min-width: 900px)` so it applies only when the viewport is wide enough to absorb it.
* `article table { display: block; max-width: 100%; overflow-x: auto; }` so wide tables scroll within the article column instead of forcing the whole page to scroll.

## Tests

* `TestPreBleedOutGuardedByMediaQuery` — fails if the `pre` base rule still declares the negative-margin expression outside an `@media (min-width: 900px)` block.
* `TestArticleTablesAreScrollable` — fails if `article table` lacks `display: block` + `overflow-x: auto`.

## Test plan

- [x] Full server test suite passes
- [ ] Verified on prod after pin: re-run the sweep harness, scrollWidth ≤ clientWidth on every page-viewport