### PR TITLE
fix(server): scope mobile table-scroll rule to .content-wrapper, not <article>

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1213,8 +1213,13 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
         /* Wide tables on narrow viewports get a horizontal scroll
          * container instead of overflowing the page. display: block on
          * the table preserves table-internal cell layout while letting
-         * the table itself scroll within the article column. */
-        article table {
+         * the table itself scroll within its column.
+         *
+         * Scoped to .content-wrapper (tinkerdown's content container)
+         * rather than the semantic article element, which the renderer
+         * does not emit — v0.1.10 used the article-prefixed selector
+         * and matched nothing on every docs page. */
+        .content-wrapper table {
             display: block;
             max-width: 100%%;
             overflow-x: auto;

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -195,25 +195,32 @@ func TestPreBleedOutGuardedByMediaQuery(t *testing.T) {
 }
 
 // Regression: wide reference tables (e.g. /reference/template-support-matrix)
-// have many columns whose combined intrinsic width exceeds the article
-// column on mobile. Without `display: block; overflow-x: auto;` on
-// `article table`, the table forces the document to scroll horizontally.
-func TestArticleTablesAreScrollable(t *testing.T) {
+// have many columns whose combined intrinsic width exceeds the content
+// column on mobile. v0.1.10 added a rule but used `article table` as the
+// selector — tinkerdown does not emit a semantic <article> element, so
+// the rule matched nothing and pages still overflowed. Lock the
+// .content-wrapper-scoped selector so the rule actually matches.
+func TestContentTablesAreScrollable(t *testing.T) {
 	body := renderHomeWithSidebar(t)
 
-	idx := strings.Index(body, "article table {")
+	idx := strings.Index(body, ".content-wrapper table {")
 	if idx < 0 {
-		t.Fatal("article table rule missing — wide tables will force horizontal page overflow on mobile")
+		t.Fatal(".content-wrapper table rule missing — wide tables will force horizontal page overflow on mobile")
 	}
 	window := body[idx:]
 	if len(window) > 300 {
 		window = window[:300]
 	}
 	if !strings.Contains(window, "display: block") {
-		t.Errorf("article table must declare display: block so it can scroll independently; rule:\n%s", window)
+		t.Errorf(".content-wrapper table must declare display: block so it can scroll independently; rule:\n%s", window)
 	}
 	if !strings.Contains(window, "overflow-x: auto") {
-		t.Errorf("article table must declare overflow-x: auto; rule:\n%s", window)
+		t.Errorf(".content-wrapper table must declare overflow-x: auto; rule:\n%s", window)
+	}
+	// And explicitly assert the broken selector is GONE — defense in
+	// depth against re-introducing it.
+	if strings.Contains(body, "article table {") {
+		t.Error("`article table` selector found — tinkerdown does not emit <article>, this matches nothing")
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #241. v0.1.10 added \`article table { display: block; overflow-x: auto; }\` to fix wide-table mobile overflow, but the rule never fired because the tinkerdown renderer doesn't emit a semantic \`<article>\` element. The post-deploy sweep re-flagged 19 pages.

## Fix

Re-scope the rule to \`.content-wrapper table\` — the actual container class tinkerdown uses for page bodies.

## Tests

- \`TestContentTablesAreScrollable\` — replaces \`TestArticleTablesAreScrollable\`. Asserts the rule exists with the right selector, plus a defense-in-depth check that the broken \`article table\` selector is gone.

## Test plan

- [x] Full server test suite passes
- [ ] Re-run sweep harness against prod after pin: scrollWidth ≤ clientWidth on table-heavy pages