### PR TITLE
fix(server): inline code wraps on word boundaries instead of forcing page overflow

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1189,6 +1189,14 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
             border: 1px solid var(--code-border);
             color: var(--text-primary);
+            /* PicoCSS forces inline code to display:inline-block with
+             * its own padding, which prevents long inline code (CLI
+             * invocations, package paths, long flags) from wrapping at
+             * word boundaries — the unbreakable inline-block forces
+             * horizontal page overflow on mobile.
+             * Restore inline + allow soft-wrap inside long tokens. */
+            display: inline;
+            overflow-wrap: anywhere;
         }
 
         pre {

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -224,6 +224,34 @@ func TestContentTablesAreScrollable(t *testing.T) {
 	}
 }
 
+// Regression: PicoCSS sets `code, kbd, samp { display: inline-block }`
+// which prevents long inline <code> (CLI flags, package paths) from
+// wrapping at word boundaries — the unbreakable inline-block forces
+// horizontal page overflow on mobile. Override pico's display and add
+// overflow-wrap so long inline tokens soft-wrap.
+func TestInlineCodeIsWrappable(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+
+	// Find the base `code {` rule and check it explicitly declares
+	// display:inline + overflow-wrap. Use the leading-whitespace
+	// anchor to avoid matching `pre code {` or `.foo code {` rules.
+	idx := strings.Index(body, "        code {")
+	if idx < 0 {
+		t.Fatal("base `code` rule missing")
+	}
+	end := strings.Index(body[idx:], "}")
+	if end < 0 {
+		t.Fatal("malformed `code` rule")
+	}
+	rule := body[idx : idx+end]
+	if !strings.Contains(rule, "display: inline") {
+		t.Errorf("base `code` rule must declare display:inline to override PicoCSS inline-block; rule:\n%s", rule)
+	}
+	if !strings.Contains(rule, "overflow-wrap: anywhere") {
+		t.Errorf("base `code` rule must declare overflow-wrap:anywhere so long inline code can wrap; rule:\n%s", rule)
+	}
+}
+
 func TestSidebarToggleScriptIsBound(t *testing.T) {
 	body := renderHomeWithSidebar(t)
 	// The inline toggle script needs to be present and use the


### PR DESCRIPTION
## Summary

Third in a series tightening tinkerdown's mobile responsive behavior, surfaced by the new sitemap-driven sweep harness in livetemplate/docs.

PicoCSS sets \`code, kbd, samp { display: inline-block; padding: .375rem }\`. This makes long inline \`<code>\` (CLI invocations, package paths, long flags) behave as an indivisible inline-block that cannot break at word boundaries — forcing horizontal page overflow on mobile.

After v0.1.10 (pre negative-margin → media query) and v0.1.11 (table scroll selector), the sweep flagged \`/cli/\` as the only remaining mobile-overflow page (scrollWidth=547 vs viewport=393). Diagnosis: a single \`<code>\` element with PicoCSS's inline-block display, holding a long CLI command.

## Fix

Override pico's display on the base \`code\` rule and add \`overflow-wrap: anywhere\` so long inline tokens soft-wrap inside words. The \`pre code\` rule (block context) is unaffected; long content inside \`<pre>\` still scrolls horizontally within the pre as intended.

## Tests

- \`TestInlineCodeIsWrappable\` — asserts the base \`code\` rule declares both \`display: inline\` and \`overflow-wrap: anywhere\`.

## Test plan

- [x] Full server suite passes
- [ ] Re-run sweep against prod: zero overflows on iPhone-14 viewport