### PR TITLE
fix(source): exec sources resolve ./ and ../ commands against siteDir (#244)

### DIFF
--- a/internal/source/exec.go
+++ b/internal/source/exec.go
@@ -90,6 +90,24 @@ func (s *ExecSource) Name() string {
 	return s.name
 }
 
+// resolveCmdPath turns a relative './path' or '../path' into an absolute
+// path under siteDir. Without this, exec.Command's behavior for './'
+// commands varies across Go runtimes and platforms (see issue #244):
+// the path is sometimes resolved relative to the process CWD before
+// cmd.Dir is applied, breaking the user's mental model that
+// cmd: "./script.sh" means "the script.sh next to my tinkerdown.yaml".
+// Bare names like 'curl' and absolute paths pass through unchanged so
+// PATH lookup still works as expected.
+func resolveCmdPath(cmdName, siteDir string) string {
+	if siteDir == "" {
+		return cmdName
+	}
+	if strings.HasPrefix(cmdName, "./") || strings.HasPrefix(cmdName, "../") {
+		return filepath.Join(siteDir, cmdName)
+	}
+	return cmdName
+}
+
 // Fetch executes the command and parses output according to format
 func (s *ExecSource) Fetch(ctx context.Context) ([]map[string]interface{}, error) {
 	// Parse command - split by spaces (simple parsing)
@@ -98,7 +116,7 @@ func (s *ExecSource) Fetch(ctx context.Context) ([]map[string]interface{}, error
 		return nil, fmt.Errorf("exec source %q: empty command", s.name)
 	}
 
-	cmdName := parts[0]
+	cmdName := resolveCmdPath(parts[0], s.siteDir)
 	args := parts[1:]
 
 	// Create command with context and timeout
@@ -272,7 +290,7 @@ func (s *ExecSource) FetchWithArgs(ctx context.Context, args map[string]string) 
 		return nil, fmt.Errorf("exec source %q: empty command", s.name)
 	}
 
-	cmdName := parts[0]
+	cmdName := resolveCmdPath(parts[0], s.siteDir)
 
 	// Build new arguments from the provided map
 	var newArgs []string

--- a/internal/source/exec_test.go
+++ b/internal/source/exec_test.go
@@ -52,7 +52,7 @@ func TestExecSourceFetchJSON(t *testing.T) {
 
 	// Create a script that outputs JSON array
 	scriptPath := filepath.Join(tmpDir, "data.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo '[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]'
 `
 	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755)
@@ -79,7 +79,7 @@ func TestExecSourceFetchSingleObject(t *testing.T) {
 
 	// Create a script that outputs a single JSON object
 	scriptPath := filepath.Join(tmpDir, "single.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo '{"status":"ok","count":42}'
 `
 	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755)
@@ -104,7 +104,7 @@ func TestExecSourceFetchNDJSON(t *testing.T) {
 
 	// Create a script that outputs newline-delimited JSON
 	scriptPath := filepath.Join(tmpDir, "ndjson.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo '{"line":1}'
 echo '{"line":2}'
 echo '{"line":3}'
@@ -132,7 +132,7 @@ func TestExecSourceFetchEmptyOutput(t *testing.T) {
 
 	// Create a script with empty output
 	scriptPath := filepath.Join(tmpDir, "empty.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo ""
 `
 	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755)
@@ -154,7 +154,7 @@ func TestExecSourceFetchInvalidJSON(t *testing.T) {
 
 	// Create a script with invalid JSON
 	scriptPath := filepath.Join(tmpDir, "invalid.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo 'not valid json'
 `
 	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755)
@@ -176,7 +176,7 @@ func TestExecSourceFetchCommandFails(t *testing.T) {
 
 	// Create a script that exits with error
 	scriptPath := filepath.Join(tmpDir, "fail.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 exit 1
 `
 	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755)
@@ -231,7 +231,7 @@ func TestExecSourceWithAllowExec(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, "test.sh")
-	err := os.WriteFile(scriptPath, []byte("#!/bin/bash\necho '{\"ok\":true}'"), 0755)
+	err := os.WriteFile(scriptPath, []byte("#!/usr/bin/env bash\necho '{\"ok\":true}'"), 0755)
 	require.NoError(t, err)
 
 	cfg := config.SourceConfig{
@@ -253,7 +253,7 @@ func TestExecSourceWithAllowExec(t *testing.T) {
 func TestExecSourceLinesFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, "lines.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo "first line"
 echo "second line"
 echo "third line"
@@ -287,7 +287,7 @@ echo "third line"
 func TestExecSourceCSVFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, "csv.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo "name,age,city"
 echo "Alice,30,NYC"
 echo "Bob,25,LA"
@@ -322,7 +322,7 @@ func TestExecSourceCustomDelimiter(t *testing.T) {
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, "tsv.sh")
 	// Tab-separated values
-	scriptContent := "#!/bin/bash\necho -e \"id\\tname\\tvalue\"\necho -e \"1\\tAlpha\\t100\"\necho -e \"2\\tBeta\\t200\"\n"
+	scriptContent := "#!/usr/bin/env bash\necho -e \"id\\tname\\tvalue\"\necho -e \"1\\tAlpha\\t100\"\necho -e \"2\\tBeta\\t200\"\n"
 	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755)
 	require.NoError(t, err)
 
@@ -355,7 +355,7 @@ func TestExecSourceEnvVars(t *testing.T) {
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, "env.sh")
 	// Script echoes the env vars as JSON
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo "{\"my_var\":\"$MY_VAR\",\"expanded\":\"$EXPANDED_VAR\"}"
 `
 	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755)
@@ -401,7 +401,7 @@ func TestExecSourceTimeout(t *testing.T) {
 func TestExecSourceEmptyLines(t *testing.T) {
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, "empty_lines.sh")
-	scriptContent := `#!/bin/bash
+	scriptContent := `#!/usr/bin/env bash
 echo "line one"
 echo ""
 echo "line two"
@@ -433,4 +433,30 @@ echo "line three"
 	assert.Equal(t, 1, data[1]["index"])
 	assert.Equal(t, "line three", data[2]["line"])
 	assert.Equal(t, 2, data[2]["index"])
+}
+
+// Issue #244: exec.Command's behavior for './' and '../' commands
+// varied across Go runtimes / platforms — the path was sometimes
+// resolved against the process CWD before cmd.Dir applied. Lock the
+// "resolve relative to siteDir" semantics here.
+func TestResolveCmdPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		cmdName string
+		siteDir string
+		want    string
+	}{
+		{"dot-slash joins siteDir", "./script.sh", "/site", "/site/script.sh"},
+		{"dotdot-slash joins siteDir", "../parent.sh", "/site/sub", "/site/parent.sh"},
+		{"absolute path passes through", "/usr/bin/curl", "/site", "/usr/bin/curl"},
+		{"bare name passes through (PATH lookup)", "curl", "/site", "curl"},
+		{"empty siteDir is no-op", "./script.sh", "", "./script.sh"},
+		{"sub-relative bare path passes through", "scripts/foo.sh", "/site", "scripts/foo.sh"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveCmdPath(tc.cmdName, tc.siteDir)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }


### PR DESCRIPTION
Closes #244.

## Summary

Two layered bugs caused all 12 ExecSource tests to fail on local arm64 runs while passing in CI on amd64 Ubuntu. Both fixed.

### Production bug

When a tinkerdown.yaml exec source declared \`cmd: \"./script.sh\"\`, the relative path was sometimes resolved against the process CWD (before \`cmd.Dir\` applied) — depending on Go runtime and platform behavior. Users intuitively expect the path to be relative to the site directory the source was configured for.

**Fix:** a small \`resolveCmdPath\` helper that prepends \`siteDir\` when the command starts with \`./\` or \`../\`. Bare names like \`curl\` and absolute paths pass through unchanged so PATH lookup still works as expected. Applied to both \`Fetch\` and \`FetchWithArgs\` entry points.

### Test fixture bug (surfaced once the production fix worked)

The test scripts used \`#!/bin/bash\`, which doesn't exist on NixOS (no \`/bin/bash\` symlink). The kernel's execve returns ENOENT when the interpreter is missing — the same \"no such file or directory\" message as a missing script. This masked the real failure.

**Fix:** globally replace \`#!/bin/bash\` → \`#!/usr/bin/env bash\` across \`exec_test.go\` (12 occurrences). Portable across FHS and non-FHS systems without changing test semantics.

## Tests

- All 12 \`TestExecSource*\` tests now pass on arm64 NixOS.
- New \`TestResolveCmdPath\` with 6 sub-cases covering each branch:
  - \`./script.sh\` joins siteDir
  - \`../parent.sh\` joins siteDir
  - absolute \`/usr/bin/curl\` passes through
  - bare \`curl\` passes through (PATH lookup intact)
  - empty siteDir is a no-op
  - sub-relative \`scripts/foo.sh\` passes through

## Test plan

- [x] All ExecSource tests pass locally (arm64 NixOS)
- [x] Full \`go test -tags=ci -skip='E2E|e2e' ./...\` passes (CI flag set)
- [ ] CI green on amd64 Ubuntu