### PR TITLE
fix(server): body width subtracts sidebar so desktop doesn't overflow horizontally

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2044,12 +2044,20 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             font-weight: 600;
         }
 
-        /* Adjust main content to make room for navigation */
+        /* Adjust main content to make room for navigation.
+         * width must subtract the sidebar width: body's natural width
+         * is 100vw, and margin-left does NOT shrink it (margins live
+         * outside the box even with box-sizing: border-box). Without
+         * the explicit width, body is 100vw wide AND shifted right by
+         * the sidebar width, creating ~360px of horizontal page
+         * overflow on desktop and a wide visible gap between the
+         * sidebar's right edge and the centered content-wrapper. */
         body:has(.tinkerdown-nav-sidebar) {
             margin-left: 360px;
             margin-right: 0;
             margin-bottom: 60px;
             max-width: none;
+            width: calc(100%% - 360px);
         }
 
         /* Responsive Navigation */
@@ -2064,6 +2072,7 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
 
             body:has(.tinkerdown-nav-sidebar) {
                 margin-left: 320px;
+                width: calc(100%% - 320px);
             }
         }
 

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -252,6 +252,38 @@ func TestInlineCodeIsWrappable(t *testing.T) {
 	}
 }
 
+// Regression: body has margin-left: <sidebar-width> to clear the
+// fixed-position sidebar, but margin-left does NOT shrink the body's
+// own width (margins live outside the box even with box-sizing:
+// border-box). Without an explicit width: calc(100% - <sidebar-width>),
+// body's natural 100vw width plus the sidebar margin produces a total
+// horizontal footprint of 100vw + sidebar-width, forcing the document
+// into horizontal scroll on desktop and creating a wide visible gap
+// between the sidebar's right edge and the centered content-wrapper.
+func TestBodyWidthSubtractsSidebar(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+
+	// Find the base body:has(.tinkerdown-nav-sidebar) rule.
+	idx := strings.Index(body, "body:has(.tinkerdown-nav-sidebar) {")
+	if idx < 0 {
+		t.Fatal("body:has(.tinkerdown-nav-sidebar) rule missing")
+	}
+	end := strings.Index(body[idx:], "}")
+	rule := body[idx : idx+end]
+	if !strings.Contains(rule, "margin-left: 360px") {
+		t.Errorf("base sidebar rule should declare margin-left: 360px; rule:\n%s", rule)
+	}
+	if !strings.Contains(rule, "width: calc(100% - 360px)") {
+		t.Errorf("base sidebar rule MUST declare width: calc(100%% - 360px) so body footprint = viewport; rule:\n%s", rule)
+	}
+
+	// And the @media (max-width: 1024px) rule that narrows the sidebar
+	// to 320px must apply the matching width override.
+	if !strings.Contains(body, "width: calc(100% - 320px)") {
+		t.Error("the 1024px breakpoint must also override width: calc(100% - 320px) to match its 320px sidebar")
+	}
+}
+
 func TestSidebarToggleScriptIsBound(t *testing.T) {
 	body := renderHomeWithSidebar(t)
 	// The inline toggle script needs to be present and use the


### PR DESCRIPTION
## Summary

User-reported desktop visual bug after the v0.1.10–v0.1.12 mobile-overflow series. Two symptoms, one root cause:

1. Document is horizontally scrollable by ~360px on desktop (no sidebar should be needed)
2. Wide ~190px gap between the sidebar's right edge and the centered \`.content-wrapper\`

## Root cause

The \`body:has(.tinkerdown-nav-sidebar)\` rule sets \`margin-left: 360px\` to clear the fixed-position sidebar — but **margins live outside the box even with \`box-sizing: border-box\`**. So body remained 100vw wide AND shifted right by 360px → total horizontal footprint = **100vw + 360px**.

Then \`.content-wrapper { max-width: 900px; margin: 0 auto }\` centered itself inside the over-wide body, ending up roughly \`(1280 - 900)/2 + 360 = 550px\` from the viewport's left edge. Sidebar ends at 360 → ~190px visible gap.

## Fix

Add \`width: calc(100% - 360px)\` to the base sidebar rule and the matching \`calc(100% - 320px)\` to the \`@media (max-width: 1024px)\` breakpoint (which narrows the sidebar to 320px). Mobile (\`max-width: 768px\`) is unaffected because it already sets \`margin-left: 0\`.

## Why the mobile sweep didn't catch this

The sweep harness in \`livetemplate/docs/e2e/cmd/sweep/\` uses \`document.body.scrollWidth\`, which body's own scroll context masks. This bug only surfaces in \`document.documentElement.scrollWidth\`. The harness should be updated to check both — filing as follow-up.

## Tests

- \`TestBodyWidthSubtractsSidebar\` — asserts the base + 1024px breakpoint rules both declare the matching \`width: calc(100% - <sidebar-width>)\`.

## Test plan

- [x] Full server test suite passes
- [ ] Verified on prod after pin: \`documentElement.scrollWidth == clientWidth\` at 1280×800