### PR TITLE
fix(server): mobile body width resets to 100% (urgent v0.1.13 regression)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2093,10 +2093,14 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             }
 
             /* Make room for the fixed-position toggle so it doesn't overlap
-             * the page H1. Only applied when a sidebar exists. */
+             * the page H1. Only applied when a sidebar exists.
+             * width: 100%% explicitly resets the desktop calc(100%% - 360px)
+             * — without this override, body collapses to 33px on a 393px
+             * mobile viewport and content stacks one character per line. */
             body:has(.tinkerdown-nav-sidebar) {
                 margin-left: 0;
                 padding-top: 3.5rem;
+                width: 100%%;
             }
 
             .tinkerdown-nav-bottom {

--- a/internal/server/sidebar_responsive_test.go
+++ b/internal/server/sidebar_responsive_test.go
@@ -284,6 +284,47 @@ func TestBodyWidthSubtractsSidebar(t *testing.T) {
 	}
 }
 
+// Regression for the v0.1.13 → v0.1.14 mobile breakage: the desktop
+// fix added `width: calc(100% - 360px)` to the base body rule, but the
+// @media (max-width: 768px) block — which sets margin-left: 0 to hide
+// the sidebar on mobile — did NOT also override width. Body inherited
+// the desktop calc, evaluating to 393 - 360 = 33px on iPhone 14, and
+// page text stacked one character per line ("Install" became I/n/s/t/a/l/l).
+// Lock in: the body:has(.tinkerdown-nav-sidebar) rule that resets
+// margin-left to 0 must ALSO reset width to 100%.
+func TestMobileBodyWidthResetsToFullViewport(t *testing.T) {
+	body := renderHomeWithSidebar(t)
+
+	// Walk through every body:has(.tinkerdown-nav-sidebar) rule body
+	// and find the one that contains "margin-left: 0" — that's the
+	// mobile reset rule, which must also reset width.
+	const marker = "body:has(.tinkerdown-nav-sidebar) {"
+	rest := body
+	var mobileRule string
+	for {
+		idx := strings.Index(rest, marker)
+		if idx < 0 {
+			break
+		}
+		end := strings.Index(rest[idx:], "}")
+		if end < 0 {
+			break
+		}
+		rule := rest[idx : idx+end]
+		if strings.Contains(rule, "margin-left: 0;") || strings.Contains(rule, "margin-left: 0\n") {
+			mobileRule = rule
+			break
+		}
+		rest = rest[idx+end:]
+	}
+	if mobileRule == "" {
+		t.Fatal("no body:has(.tinkerdown-nav-sidebar) rule with margin-left: 0 found — mobile body sizing is unhandled")
+	}
+	if !strings.Contains(mobileRule, "width: 100%") {
+		t.Errorf("the mobile body rule (margin-left: 0) MUST declare width: 100%% to override the desktop calc(100%% - 360px), otherwise body collapses to ~33px on a 393px viewport; rule:\n%s", mobileRule)
+	}
+}
+
 func TestSidebarToggleScriptIsBound(t *testing.T) {
 	body := renderHomeWithSidebar(t)
 	// The inline toggle script needs to be present and use the


### PR DESCRIPTION
## Urgent

v0.1.13 broke mobile rendering. Body collapses to ~33px wide on a 393px iPhone 14 viewport, causing all text to stack one character per line. Site is currently broken on mobile in production.

## Root cause

v0.1.13 added \`width: calc(100% - 360px)\` to the BASE \`body:has(.tinkerdown-nav-sidebar)\` rule to fix desktop horizontal overflow. But the \`@media (max-width: 768px)\` block — which sets \`margin-left: 0\` to hide the sidebar on mobile — did NOT also override width. Body inherited the desktop calc, evaluating to 393 - 360 = **33px**.

## Fix

Add \`width: 100%\` to the mobile @media block alongside the existing margin-left: 0 reset.

## Tests

- \`TestMobileBodyWidthResetsToFullViewport\` — walks every \`body:has(.tinkerdown-nav-sidebar)\` rule body, finds the one with \`margin-left: 0\` (the mobile reset rule), and asserts it also declares \`width: 100%\`. Catches the exact class of bug that just shipped.

## Test plan

- [x] All sidebar responsive tests pass (11/11 including 3 new regressions from this PR series)
- [ ] Verified on prod after pin: mobile body width = 393px, no character-stacking