### PR TITLE
feat(parser): pass raw HTML through goldmark by default

### DIFF
--- a/page.go
+++ b/page.go
@@ -59,9 +59,10 @@ func ParseFile(path string) (*Page, error) {
 		}
 	}
 
-	// Parse markdown with partial support
+	// Parse markdown with partial support. File-based content is trusted, so
+	// raw HTML in the markdown body passes through.
 	baseDir := filepath.Dir(absPath)
-	fm, codeBlocks, staticHTML, err := ParseMarkdownWithPartials(processedContent, baseDir)
+	fm, codeBlocks, staticHTML, err := ParseMarkdownWithPartials(processedContent, baseDir, true)
 	if err != nil {
 		// Wrap with file context
 		return nil, NewParseError(absPath, 1, fmt.Sprintf("Failed to parse markdown: %v", err))
@@ -180,11 +181,14 @@ func (pc *PageConfig) MergeFromFrontmatter(fm *Frontmatter) {
 
 // ParseString parses markdown content from a string and creates a Page.
 // This is useful for the playground where content comes from user input.
+// Raw HTML in the body is omitted to prevent XSS — playground submissions
+// are untrusted.
 func ParseString(content string) (*Page, error) {
 	// Note: preprocessAutoTasks is skipped here — playground input uses explicit
 	// lvt blocks rather than auto-detected task sections from file-based markdown.
-	// Parse markdown (no partials support for string input)
-	fm, codeBlocks, staticHTML, err := ParseMarkdownWithPartials([]byte(content), "")
+	// Parse markdown (no partials support for string input). allowRawHTML=false
+	// because content is user-submitted; <script>/<iframe>/<style> get stripped.
+	fm, codeBlocks, staticHTML, err := ParseMarkdownWithPartials([]byte(content), "", false)
 	if err != nil {
 		return nil, NewParseError("playground", 1, fmt.Sprintf("Failed to parse markdown: %v", err))
 	}
@@ -219,11 +223,14 @@ func ParseString(content string) (*Page, error) {
 // BuildPage creates a Page from raw content with a specified ID and source file.
 // This is useful for testing and programmatic page creation.
 // The content should be valid markdown with optional frontmatter.
+//
+// Treats input as trusted (programmatic/test callers control the content) —
+// raw HTML in the markdown body is preserved.
 func BuildPage(id, sourceFile string, content []byte) (*Page, error) {
 	// Note: preprocessAutoTasks is skipped here — programmatic/test callers
 	// provide pre-built content with explicit lvt blocks.
 	// Parse markdown (no partials support for programmatic input)
-	fm, codeBlocks, staticHTML, err := ParseMarkdownWithPartials(content, "")
+	fm, codeBlocks, staticHTML, err := ParseMarkdownWithPartials(content, "", true)
 	if err != nil {
 		return nil, NewParseError(sourceFile, 1, fmt.Sprintf("Failed to parse markdown: %v", err))
 	}

--- a/parser.go
+++ b/parser.go
@@ -155,7 +155,38 @@ type CodeBlock struct {
 	Line     int // Line number in source file
 }
 
+// newGoldmarkParser builds the shared goldmark configuration used by every
+// parse path in this package. allowRawHTML controls whether raw HTML in the
+// markdown body passes through to the rendered output (CommonMark default
+// is to omit it for safety).
+//
+// Pass true for content authored by the site owner (file-based pages, build
+// tools, programmatic test input) — that's the same trust posture as a Go
+// template and matches what Hugo, MkDocs, Docusaurus, mdBook do by default.
+//
+// Pass false for content sourced from arbitrary user input (the playground
+// receives markdown over HTTP). Without this guard a user can submit
+// <script>...</script> and execute JS on the same origin, since the docs
+// CSP allows 'unsafe-inline' for the document itself.
+func newGoldmarkParser(allowRawHTML bool) goldmark.Markdown {
+	opts := []goldmark.Option{
+		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+	}
+	if allowRawHTML {
+		opts = append(opts, goldmark.WithRendererOptions(
+			gmhtml.WithUnsafe(),
+		))
+	}
+	return goldmark.New(opts...)
+}
+
 // ParseMarkdown parses a markdown file and extracts frontmatter and code blocks.
+// Treats the input as trusted (file-based) content — raw HTML in the markdown
+// body is preserved. For untrusted input use ParseMarkdownWithPartials with
+// allowRawHTML=false.
 func ParseMarkdown(content []byte) (*Frontmatter, []*CodeBlock, string, error) {
 	// Extract frontmatter
 	frontmatter, remaining, err := extractFrontmatter(content)
@@ -163,21 +194,7 @@ func ParseMarkdown(content []byte) (*Frontmatter, []*CodeBlock, string, error) {
 		return nil, nil, "", fmt.Errorf("failed to parse frontmatter: %w", err)
 	}
 
-	// Parse markdown with goldmark. WithUnsafe() lets raw HTML in markdown
-	// pass through to the rendered output — matches CommonMark behavior and
-	// what other static-site generators (Hugo, MkDocs, Docusaurus) do by
-	// default. Tinkerdown's threat model is author-controlled markdown, not
-	// arbitrary user input, so the default-omit behavior surprises authors
-	// who expect <iframe>, <details>, <video> etc. to render.
-	md := goldmark.New(
-		goldmark.WithExtensions(extension.GFM),
-		goldmark.WithParserOptions(
-			parser.WithAutoHeadingID(),
-		),
-		goldmark.WithRendererOptions(
-			gmhtml.WithUnsafe(),
-		),
-	)
+	md := newGoldmarkParser(true)
 
 	reader := text.NewReader(remaining)
 	doc := md.Parser().Parse(reader)
@@ -1190,7 +1207,13 @@ func ProcessPartials(content []byte, baseDir string, seen map[string]bool) ([]by
 
 // ParseMarkdownWithPartials parses markdown with partial file support.
 // baseDir is used to resolve relative paths in {{partial "file.md"}} directives.
-func ParseMarkdownWithPartials(content []byte, baseDir string) (*Frontmatter, []*CodeBlock, string, error) {
+//
+// allowRawHTML controls whether <script>, <iframe>, etc. in the markdown body
+// pass through to the rendered output. Pass true for trusted file-based or
+// programmatic content; pass false when the input came from a user
+// (playground via ParseString). See newGoldmarkParser for the threat-model
+// rationale.
+func ParseMarkdownWithPartials(content []byte, baseDir string, allowRawHTML bool) (*Frontmatter, []*CodeBlock, string, error) {
 	// First, extract frontmatter before processing partials
 	frontmatter, remaining, err := extractFrontmatter(content)
 	if err != nil {
@@ -1203,20 +1226,7 @@ func ParseMarkdownWithPartials(content []byte, baseDir string) (*Frontmatter, []
 		return nil, nil, "", err
 	}
 
-	// Now parse the processed content (without frontmatter since we already extracted it)
-	// We need to reconstruct the content for ParseMarkdown or parse directly here
-
-	// Parse markdown with goldmark. See the WithUnsafe rationale on the
-	// other goldmark.New site above.
-	md := goldmark.New(
-		goldmark.WithExtensions(extension.GFM),
-		goldmark.WithParserOptions(
-			parser.WithAutoHeadingID(),
-		),
-		goldmark.WithRendererOptions(
-			gmhtml.WithUnsafe(),
-		),
-	)
+	md := newGoldmarkParser(allowRawHTML)
 
 	reader := text.NewReader(processed)
 	doc := md.Parser().Parse(reader)

--- a/parser.go
+++ b/parser.go
@@ -18,6 +18,7 @@ import (
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
+	gmhtml "github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
 	"gopkg.in/yaml.v3"
 )
@@ -162,11 +163,19 @@ func ParseMarkdown(content []byte) (*Frontmatter, []*CodeBlock, string, error) {
 		return nil, nil, "", fmt.Errorf("failed to parse frontmatter: %w", err)
 	}
 
-	// Parse markdown with goldmark
+	// Parse markdown with goldmark. WithUnsafe() lets raw HTML in markdown
+	// pass through to the rendered output — matches CommonMark behavior and
+	// what other static-site generators (Hugo, MkDocs, Docusaurus) do by
+	// default. Tinkerdown's threat model is author-controlled markdown, not
+	// arbitrary user input, so the default-omit behavior surprises authors
+	// who expect <iframe>, <details>, <video> etc. to render.
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.GFM),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithRendererOptions(
+			gmhtml.WithUnsafe(),
 		),
 	)
 
@@ -1197,11 +1206,15 @@ func ParseMarkdownWithPartials(content []byte, baseDir string) (*Frontmatter, []
 	// Now parse the processed content (without frontmatter since we already extracted it)
 	// We need to reconstruct the content for ParseMarkdown or parse directly here
 
-	// Parse markdown with goldmark
+	// Parse markdown with goldmark. See the WithUnsafe rationale on the
+	// other goldmark.New site above.
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.GFM),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithRendererOptions(
+			gmhtml.WithUnsafe(),
 		),
 	)
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1376,3 +1376,61 @@ func TestRawHTMLPassesThrough(t *testing.T) {
 		})
 	}
 }
+
+// TestParseMarkdownWithPartialsRespectsAllowRawHTML verifies the trust flag
+// gates raw-HTML passthrough on a per-call basis: trusted callers (file-based
+// content, BuildPage) get raw HTML through; untrusted callers (playground)
+// get it stripped.
+func TestParseMarkdownWithPartialsRespectsAllowRawHTML(t *testing.T) {
+	const xss = `<script>alert('xss')</script>`
+
+	t.Run("trusted_passes_script_through", func(t *testing.T) {
+		_, _, html, err := ParseMarkdownWithPartials([]byte(xss), "", true)
+		if err != nil {
+			t.Fatalf("ParseMarkdownWithPartials(true) error = %v", err)
+		}
+		if !strings.Contains(html, "<script>") {
+			t.Errorf("trusted parse should preserve <script>, got:\n%s", html)
+		}
+	})
+
+	t.Run("untrusted_strips_script", func(t *testing.T) {
+		_, _, html, err := ParseMarkdownWithPartials([]byte(xss), "", false)
+		if err != nil {
+			t.Fatalf("ParseMarkdownWithPartials(false) error = %v", err)
+		}
+		if strings.Contains(html, "<script>") {
+			t.Errorf("untrusted parse must strip <script>, got:\n%s", html)
+		}
+	})
+}
+
+// TestParseStringStripsRawHTML guards the playground path. ParseString is
+// the public entry point used by internal/server/playground.go to render
+// markdown submitted by users over HTTP. The renderer MUST omit raw HTML
+// here, otherwise a user can inject <script> and execute JS on the same
+// origin (the docs CSP allows 'unsafe-inline' for the document).
+func TestParseStringStripsRawHTML(t *testing.T) {
+	cases := []struct {
+		name string
+		md   string
+	}{
+		{"script_tag", `<script>alert('xss')</script>`},
+		{"img_with_onerror", `<img src=x onerror="alert('xss')">`},
+		{"iframe_with_javascript_url", `<iframe src="javascript:alert('xss')"></iframe>`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			page, err := ParseString(tc.md)
+			if err != nil {
+				t.Fatalf("ParseString error = %v", err)
+			}
+			if strings.Contains(page.StaticHTML, "<script>") ||
+				strings.Contains(page.StaticHTML, "onerror=") ||
+				strings.Contains(page.StaticHTML, "javascript:") {
+				t.Errorf("playground rendering must not contain executable HTML, got:\n%s", page.StaticHTML)
+			}
+		})
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1418,6 +1418,11 @@ func TestParseStringStripsRawHTML(t *testing.T) {
 		{"script_tag", `<script>alert('xss')</script>`},
 		{"img_with_onerror", `<img src=x onerror="alert('xss')">`},
 		{"iframe_with_javascript_url", `<iframe src="javascript:alert('xss')"></iframe>`},
+		// Markdown-native (not raw HTML): goldmark's URL sanitizer blocks
+		// these even without WithUnsafe, but the playground has no test
+		// pinning that guarantee — record it explicitly.
+		{"markdown_link_javascript_url", `[click me](javascript:alert('xss'))`},
+		{"markdown_image_data_url", `![](data:text/html,<script>alert(1)</script>)`},
 	}
 
 	for _, tc := range cases {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1326,3 +1326,53 @@ charts:
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// TestRawHTMLPassesThrough verifies the goldmark renderer is configured with
+// WithUnsafe so that author-written raw HTML (iframe, details, video, etc.)
+// reaches the rendered output. Without this, goldmark substitutes
+// "<!-- raw HTML omitted -->" for inline raw HTML, which surprises authors
+// expecting CommonMark passthrough behavior. Tinkerdown's threat model is
+// trusted authors, not arbitrary user input.
+func TestRawHTMLPassesThrough(t *testing.T) {
+	cases := []struct {
+		name string
+		md   string
+		want string // substring that must appear in the rendered HTML
+	}{
+		{
+			name: "iframe block",
+			md:   `<iframe src="/demo" title="Demo" loading="lazy"></iframe>`,
+			want: `<iframe src="/demo"`,
+		},
+		{
+			name: "details block",
+			md: "<details>\n<summary>Click me</summary>\nHidden content.\n</details>",
+			want: "<details>",
+		},
+		{
+			name: "inline span with class",
+			md:   `Some text with a <span class="note">note</span>.`,
+			want: `<span class="note">`,
+		},
+		{
+			name: "video element",
+			md:   `<video src="/demo.mp4" controls></video>`,
+			want: `<video src="/demo.mp4"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, html, err := ParseMarkdown([]byte(tc.md))
+			if err != nil {
+				t.Fatalf("ParseMarkdown() error = %v", err)
+			}
+			if !strings.Contains(html, tc.want) {
+				t.Errorf("rendered HTML did not contain %q\nfull output:\n%s", tc.want, html)
+			}
+			if strings.Contains(html, "raw HTML omitted") {
+				t.Errorf("rendered HTML still contains 'raw HTML omitted' — WithUnsafe missing\nfull output:\n%s", html)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `goldmark.WithRendererOptions(gmhtml.WithUnsafe())` to both `goldmark.New` call sites in `parser.go`.
- Without this, goldmark substitutes `<!-- raw HTML omitted -->` for inline raw HTML — surprising authors who expect CommonMark passthrough behavior.

## Why
Tinkerdown processes author-controlled markdown (the trust posture is closer to a Go template than to user-submitted comments). The default-omit behavior is a defensive misnomer for libraries that might process untrusted markdown — that's not tinkerdown's threat model. Other static-site generators (Hugo, MkDocs, Docusaurus, mdBook) all pass raw HTML through by default for the same reason.

This also unblocks embedding `<iframe>`, `<video>`, `<details>` inline in tinkerdown markdown — the immediate consumer is the LiveTemplate docs site, where we want to embed a small live demo on the landing page (proxied same-origin).

## Test plan
- [x] `go test -run TestRawHTMLPassesThrough ./...` — new 4-case test passes (iframe, details, inline span with class, video element)
- [x] `go test ./...` for the full parser suite — golden + frontmatter + code-blocks all still green
- [ ] CI green
- [ ] Manual: render a docs page with `<iframe>` and confirm it survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)