### PR TITLE
feat(server): configurable CSP frame-src for cross-origin iframes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -490,8 +490,8 @@ type SecurityConfig struct {
 // typo surfaces at startup instead of as a silently-broken iframe.
 func (c SecurityConfig) Validate() error {
 	for _, origin := range c.FrameSrc {
-		if strings.ContainsAny(origin, ";\r\n \t") {
-			return fmt.Errorf("security.frame_src entry %q contains an invalid character (no spaces, tabs, semicolons, or newlines allowed)", origin)
+		if strings.ContainsAny(origin, ";,\r\n \t") {
+			return fmt.Errorf("security.frame_src entry %q contains an invalid character (no spaces, tabs, commas, semicolons, or newlines allowed)", origin)
 		}
 		u, err := url.Parse(origin)
 		if err != nil || u.Scheme == "" || u.Host == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	API         *APIConfig              `yaml:"api,omitempty"`
 	Webhooks    map[string]*Webhook     `yaml:"webhooks,omitempty"`
 	Outputs     map[string]*OutputConfig `yaml:"outputs,omitempty"`
+	Security    SecurityConfig          `yaml:"security,omitempty"`
 
 	// VersionPrefix, when non-empty, becomes a URL path segment that is
 	// stripped from incoming requests before route resolution. Routes serve
@@ -460,6 +461,21 @@ type NavSection struct {
 type NavPage struct {
 	Title string `yaml:"title"` // Page title (e.g., "Installation")
 	Path  string `yaml:"path"`  // Page path (e.g., "getting-started/installation.md")
+}
+
+// SecurityConfig exposes site-level security knobs that change emitted
+// security response headers. Currently scoped to CSP overrides; further
+// fields can be added without breaking existing configs because the
+// struct is yaml-omitempty.
+type SecurityConfig struct {
+	// FrameSrc lists origins appended to the CSP frame-src directive,
+	// in addition to the implicit 'self'. Set this when the site embeds
+	// cross-origin iframes (e.g., a separately-deployed app loaded as a
+	// live demo on a docs page). Each entry is emitted verbatim, so use
+	// scheme + host (e.g., "https://lt-landing-demo.fly.dev"). When the
+	// list is empty no frame-src directive is emitted, falling back to
+	// default-src 'self' which blocks cross-origin frames.
+	FrameSrc []string `yaml:"frame_src,omitempty"`
 }
 
 // ServerConfig holds server-related configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,8 +3,10 @@ package config
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -471,11 +473,32 @@ type SecurityConfig struct {
 	// FrameSrc lists origins appended to the CSP frame-src directive,
 	// in addition to the implicit 'self'. Set this when the site embeds
 	// cross-origin iframes (e.g., a separately-deployed app loaded as a
-	// live demo on a docs page). Each entry is emitted verbatim, so use
+	// live demo on a docs page). Validate() rejects entries that contain
+	// CSP/header-injection characters or that don't parse as a URI. Use
 	// scheme + host (e.g., "https://lt-landing-demo.fly.dev"). When the
 	// list is empty no frame-src directive is emitted, falling back to
 	// default-src 'self' which blocks cross-origin frames.
 	FrameSrc []string `yaml:"frame_src,omitempty"`
+}
+
+// Validate ensures every FrameSrc entry is safe to emit verbatim into a
+// CSP header value. CSP directives are separated by `;`, and HTTP header
+// values must not contain CR/LF, so any of those characters in an
+// operator-supplied origin would either smuggle a new directive (e.g.,
+// widening script-src) or split the response header entirely. URL
+// parsing additionally rejects obviously malformed values so that a
+// typo surfaces at startup instead of as a silently-broken iframe.
+func (c SecurityConfig) Validate() error {
+	for _, origin := range c.FrameSrc {
+		if strings.ContainsAny(origin, ";\r\n \t") {
+			return fmt.Errorf("security.frame_src entry %q contains an invalid character (no spaces, tabs, semicolons, or newlines allowed)", origin)
+		}
+		u, err := url.Parse(origin)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return fmt.Errorf("security.frame_src entry %q is not a valid absolute URL (expected scheme://host)", origin)
+		}
+	}
+	return nil
 }
 
 // ServerConfig holds server-related configuration
@@ -728,6 +751,13 @@ func Load(configPath string) (*Config, error) {
 	config := DefaultConfig() // Start with defaults
 	if err := yaml.Unmarshal(data, config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	// Reject configs that would emit a malformed CSP header before
+	// any handler ever sees a request. A silently-broken CSP is much
+	// worse than a clear startup failure.
+	if err := config.Security.Validate(); err != nil {
+		return nil, err
 	}
 
 	return config, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -479,3 +479,34 @@ func TestConfigValidateOutputs(t *testing.T) {
 		})
 	}
 }
+
+func TestSecurityConfigValidate(t *testing.T) {
+	cases := []struct {
+		name      string
+		frameSrc  []string
+		wantError bool
+	}{
+		{name: "empty list", frameSrc: nil, wantError: false},
+		{name: "single valid origin", frameSrc: []string{"https://lt-landing-demo.fly.dev"}, wantError: false},
+		{name: "multiple valid origins", frameSrc: []string{"https://a.example.com", "https://b.example.com:8443"}, wantError: false},
+		{name: "rejects semicolon (CSP injection)", frameSrc: []string{"https://evil.com; script-src *"}, wantError: true},
+		{name: "rejects newline (header split)", frameSrc: []string{"https://evil.com\nX-XSS: 0"}, wantError: true},
+		{name: "rejects carriage return", frameSrc: []string{"https://evil.com\r"}, wantError: true},
+		{name: "rejects bare space", frameSrc: []string{"https://evil.com script-src *"}, wantError: true},
+		{name: "rejects empty entry", frameSrc: []string{""}, wantError: true},
+		{name: "rejects schemeless host", frameSrc: []string{"lt-landing-demo.fly.dev"}, wantError: true},
+		{name: "rejects scheme-only", frameSrc: []string{"https://"}, wantError: true},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SecurityConfig{FrameSrc: tt.frameSrc}.Validate()
+			if tt.wantError && err == nil {
+				t.Errorf("Validate() expected error for %v, got nil", tt.frameSrc)
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("Validate() unexpected error for %v: %v", tt.frameSrc, err)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -480,6 +482,28 @@ func TestConfigValidateOutputs(t *testing.T) {
 	}
 }
 
+// TestLoadRejectsInjectedFrameSrc closes the loop on the startup-failure
+// guarantee in the SecurityConfig.Validate godoc: a config file containing
+// an injection-style frame_src must surface as an error from Load(),
+// not as a silently-broken CSP at runtime.
+func TestLoadRejectsInjectedFrameSrc(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tinkerdown.yaml")
+	yaml := []byte(`title: bad
+type: tutorial
+security:
+  frame_src:
+    - "https://evil.com; script-src *"
+`)
+	if err := os.WriteFile(path, yaml, 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load() accepted a frame_src entry containing a semicolon; want error")
+	}
+}
+
 func TestSecurityConfigValidate(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -490,6 +514,7 @@ func TestSecurityConfigValidate(t *testing.T) {
 		{name: "single valid origin", frameSrc: []string{"https://lt-landing-demo.fly.dev"}, wantError: false},
 		{name: "multiple valid origins", frameSrc: []string{"https://a.example.com", "https://b.example.com:8443"}, wantError: false},
 		{name: "rejects semicolon (CSP injection)", frameSrc: []string{"https://evil.com; script-src *"}, wantError: true},
+		{name: "rejects comma (defensive)", frameSrc: []string{"https://evil.com,foo"}, wantError: true},
 		{name: "rejects newline (header split)", frameSrc: []string{"https://evil.com\nX-XSS: 0"}, wantError: true},
 		{name: "rejects carriage return", frameSrc: []string{"https://evil.com\r"}, wantError: true},
 		{name: "rejects bare space", frameSrc: []string{"https://evil.com script-src *"}, wantError: true},

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -78,27 +78,43 @@ func CORSMiddleware(origins []string, authHeaderName string) func(http.Handler) 
 }
 
 // SecurityHeadersMiddleware adds security headers to all responses.
-func SecurityHeadersMiddleware() func(http.Handler) http.Handler {
+// frameSrc is appended to the CSP frame-src directive (in addition to
+// 'self') and is typically sourced from config.SecurityConfig.FrameSrc.
+// Pass nil when no cross-origin iframes are needed.
+func SecurityHeadersMiddleware(frameSrc []string) func(http.Handler) http.Handler {
+	csp := buildCSP(frameSrc)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("X-Frame-Options", "DENY")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-			// CSP: allow self, inline styles (needed for PicoCSS and LVT rendering),
-			// unsafe-eval (needed for Mermaid.js), and data: URIs for fonts/images.
-			// connect-src 'self' covers same-origin WebSocket (ws/wss) connections.
-			w.Header().Set("Content-Security-Policy",
-				"default-src 'self'; "+
-					"script-src 'self' 'unsafe-inline' 'unsafe-eval'; "+
-					"style-src 'self' 'unsafe-inline'; "+
-					"img-src 'self' data: https:; "+
-					"font-src 'self' data:; "+
-					"connect-src 'self'; "+
-					"frame-ancestors 'none'")
+			w.Header().Set("Content-Security-Policy", csp)
 
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// buildCSP composes the Content-Security-Policy header value. The base
+// policy mirrors what tinkerdown has emitted since v0.1.x: self-only
+// scripts/styles plus inline (PicoCSS, LVT renders inline), unsafe-eval
+// (Mermaid runtime), data: URIs (fonts/images), self-only connect-src
+// (covers same-origin ws/wss). When frameSrc is non-empty a frame-src
+// directive is emitted with 'self' plus each provided origin verbatim;
+// otherwise frame-src is omitted and inherits default-src 'self', which
+// blocks cross-origin iframes.
+func buildCSP(frameSrc []string) string {
+	csp := "default-src 'self'; " +
+		"script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data: https:; " +
+		"font-src 'self' data:; " +
+		"connect-src 'self'; " +
+		"frame-ancestors 'none'"
+	if len(frameSrc) > 0 {
+		csp += "; frame-src 'self' " + strings.Join(frameSrc, " ")
+	}
+	return csp
 }
 
 // evictionLogInterval is the minimum time between eviction log messages.

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -868,3 +868,23 @@ func TestSecurityHeadersMiddleware_NoFrameSrcByDefault(t *testing.T) {
 		t.Errorf("frame-src should be omitted when not configured, got: %s", csp)
 	}
 }
+
+// TestServeHTTP_PageRouteEmitsConfiguredFrameSrc covers the second CSP
+// write site — the inline header set in Server.ServeHTTP for non-API
+// page routes. The middleware-path tests above don't exercise this path,
+// and a regression here would silently strip frame-src from every page
+// route while passing the middleware tests.
+func TestServeHTTP_PageRouteEmitsConfiguredFrameSrc(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Security.FrameSrc = []string{"https://lt-landing-demo.fly.dev"}
+	srv := NewWithConfig(t.TempDir(), cfg)
+
+	req := httptest.NewRequest("GET", "/nonexistent-page-but-headers-still-set", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	csp := w.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "frame-src 'self' https://lt-landing-demo.fly.dev") {
+		t.Errorf("page-route CSP missing configured frame-src; got: %s", csp)
+	}
+}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -771,3 +771,79 @@ func TestShardedRateLimitFallback(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildCSP(t *testing.T) {
+	cases := []struct {
+		name     string
+		frameSrc []string
+		want     []string // substrings that must appear
+		notWant  []string // substrings that must NOT appear
+	}{
+		{
+			name:     "no frame-src when nil",
+			frameSrc: nil,
+			want:     []string{"default-src 'self'", "frame-ancestors 'none'"},
+			notWant:  []string{"frame-src"},
+		},
+		{
+			name:     "no frame-src when empty slice",
+			frameSrc: []string{},
+			want:     []string{"default-src 'self'"},
+			notWant:  []string{"frame-src"},
+		},
+		{
+			name:     "single origin",
+			frameSrc: []string{"https://lt-landing-demo.fly.dev"},
+			want:     []string{"frame-src 'self' https://lt-landing-demo.fly.dev"},
+		},
+		{
+			name:     "multiple origins separated by spaces",
+			frameSrc: []string{"https://a.example.com", "https://b.example.com"},
+			want:     []string{"frame-src 'self' https://a.example.com https://b.example.com"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := buildCSP(c.frameSrc)
+			for _, sub := range c.want {
+				if !strings.Contains(got, sub) {
+					t.Errorf("CSP missing %q\nfull: %s", sub, got)
+				}
+			}
+			for _, sub := range c.notWant {
+				if strings.Contains(got, sub) {
+					t.Errorf("CSP unexpectedly contains %q\nfull: %s", sub, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSecurityHeadersMiddleware_FrameSrcEmittedFromConfig(t *testing.T) {
+	mw := SecurityHeadersMiddleware([]string{"https://upstream.example.com"})
+	wrapped := mw(okHandler())
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+
+	csp := w.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "frame-src 'self' https://upstream.example.com") {
+		t.Errorf("expected frame-src directive with upstream origin, got: %s", csp)
+	}
+	// Sanity-check the unrelated security headers still ship.
+	if got := w.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Errorf("X-Frame-Options = %q, want DENY", got)
+	}
+}
+
+func TestSecurityHeadersMiddleware_NoFrameSrcByDefault(t *testing.T) {
+	mw := SecurityHeadersMiddleware(nil)
+	wrapped := mw(okHandler())
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+
+	csp := w.Header().Get("Content-Security-Policy")
+	if strings.Contains(csp, "frame-src") {
+		t.Errorf("frame-src should be omitted when not configured, got: %s", csp)
+	}
+}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -772,6 +772,27 @@ func TestShardedRateLimitFallback(t *testing.T) {
 	}
 }
 
+// defaultCSP locks the byte-exact CSP value emitted when no security
+// overrides are configured. Touching this string means the default CSP
+// changed — review the change deliberately, then update both the test
+// and any operator-facing docs that quote the policy.
+const defaultCSP = "default-src 'self'; " +
+	"script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data: https:; " +
+	"font-src 'self' data:; " +
+	"connect-src 'self'; " +
+	"frame-ancestors 'none'"
+
+func TestBuildCSP_ByteIdenticalDefault(t *testing.T) {
+	if got := buildCSP(nil); got != defaultCSP {
+		t.Errorf("default CSP drifted\n got: %s\nwant: %s", got, defaultCSP)
+	}
+	if got := buildCSP([]string{}); got != defaultCSP {
+		t.Errorf("empty-slice CSP drifted\n got: %s\nwant: %s", got, defaultCSP)
+	}
+}
+
 func TestBuildCSP(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -146,7 +146,7 @@ func NewWithConfig(rootDir string, cfg *config.Config) *Server {
 		handler = CORSMiddleware(cfg.API.GetCORSOrigins(), authHeader)(handler)
 
 		// Apply security headers (outermost)
-		handler = SecurityHeadersMiddleware()(handler)
+		handler = SecurityHeadersMiddleware(cfg.Security.FrameSrc)(handler)
 
 		srv.apiRoutes = handler
 
@@ -395,14 +395,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-	w.Header().Set("Content-Security-Policy",
-		"default-src 'self'; "+
-			"script-src 'self' 'unsafe-inline' 'unsafe-eval'; "+
-			"style-src 'self' 'unsafe-inline'; "+
-			"img-src 'self' data: https:; "+
-			"font-src 'self' data:; "+
-			"connect-src 'self'; "+
-			"frame-ancestors 'none'")
+	w.Header().Set("Content-Security-Policy", buildCSP(s.config.Security.FrameSrc))
 
 	// Strip the configured version prefix (if any) so the rest of routing
 	// can be prefix-agnostic. With prefix unset this is a no-op. Both

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,16 +59,19 @@ type Server struct {
 	recentSourceWrites map[string]time.Time                  // Files recently written by source actions
 	sourceWriteMu      sync.Mutex                            // Protects recentSourceWrites
 	proxyRoutes        []*proxyRoute                         // Custom routes that bypass markdown resolution and reverse-proxy to upstream
+	csp                string                                // Pre-computed Content-Security-Policy header value (immutable for the server's lifetime)
 }
 
 // New creates a new server for the given root directory.
 func New(rootDir string) *Server {
+	cfg := config.DefaultConfig()
 	srv := &Server{
 		rootDir:            rootDir,
-		config:             config.DefaultConfig(),
+		config:             cfg,
 		routes:             make([]*Route, 0),
 		connections:        make(map[*websocket.Conn]*WebSocketHandler),
 		recentSourceWrites: make(map[string]time.Time),
+		csp:                buildCSP(cfg.Security.FrameSrc),
 	}
 	srv.playground = NewPlaygroundHandler(srv)
 	return srv
@@ -82,6 +85,7 @@ func NewWithConfig(rootDir string, cfg *config.Config) *Server {
 		routes:             make([]*Route, 0),
 		connections:        make(map[*websocket.Conn]*WebSocketHandler),
 		recentSourceWrites: make(map[string]time.Time),
+		csp:                buildCSP(cfg.Security.FrameSrc),
 	}
 
 	// Initialize site manager if in site mode
@@ -395,7 +399,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-	w.Header().Set("Content-Security-Policy", buildCSP(s.config.Security.FrameSrc))
+	w.Header().Set("Content-Security-Policy", s.csp)
 
 	// Strip the configured version prefix (if any) so the rest of routing
 	// can be prefix-agnostic. With prefix unset this is a no-op. Both


### PR DESCRIPTION
## Summary

- Adds `SecurityConfig.FrameSrc []string` to `tinkerdown.yaml` (`security.frame_src`).
- Threads it into both CSP write sites (API middleware + page-route inline header) via a new `buildCSP()` helper that also dedupes the previously-duplicated CSP literal.
- When set, emits `frame-src 'self' <origin> ...`; when empty, CSP is byte-identical to v0.1.15.

## Why

The docs site needs to embed a separately-deployed LiveTemplate app (`lt-landing-demo.fly.dev`) on the landing page. Same-origin reverse-proxy embedding doesn't work — the LiveTemplate client auto-derives its WebSocket URL from `window.location`, which inside a same-origin iframe points at the docs host (no matching session). Cross-origin iframe lets the embedded app's client talk to its own deployment, but the current default CSP (`default-src 'self'`) blocks the frame load until `frame-src` is configured.

The opt-in gate keeps the safe default (no cross-origin iframes) while letting site authors carefully widen it per-origin.

## Test plan

- [x] Unit: `TestBuildCSP` covers nil / empty / single / multi-origin
- [x] Unit: `TestSecurityHeadersMiddleware_FrameSrcEmittedFromConfig` verifies the header path
- [x] Unit: `TestSecurityHeadersMiddleware_NoFrameSrcByDefault` asserts the byte-identical default
- [x] CI-scope full suite: `go test -race -tags=ci -skip='E2E|e2e' ./...` green locally
- [ ] After merge: cut v0.1.16, repin docs Dockerfile, set `security.frame_src: ["https://lt-landing-demo.fly.dev"]` in docs `tinkerdown.yaml`, swap landing iframe src to the cross-origin URL, drop the now-unused `/demo/counter/` proxy route, deploy + verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)