### PR TITLE
fix(server): no-cache HTML so navigations always revalidate

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -709,6 +709,13 @@ func (s *Server) servePage(w http.ResponseWriter, r *http.Request, route *Route)
 	// For now, just serve the static HTML
 	// TODO: Add WebSocket support for interactivity
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// HTML pages are dynamic by nature: site config, frontmatter, and
+	// rendered partials change without a URL change, so a stale cached
+	// HTML response paired with fresh fingerprinted assets produces
+	// hard-to-explain "first paint missing styles" / "refresh fixes it"
+	// breakage. Force every navigation to revalidate; assets keep their
+	// long max-age=31536000 because their URLs change on rebuild.
+	w.Header().Set("Cache-Control", "no-cache, must-revalidate")
 
 	html := s.renderPage(route.Page, r.URL.Path, r.Host, detectWSScheme(r))
 	w.Write([]byte(html))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -149,6 +149,14 @@ This is a test page.`
 	if !strings.Contains(body, "Test Content") {
 		t.Error("Response does not contain page content")
 	}
+
+	// HTML responses must opt out of caching so that intermediate caches
+	// (browser, CDN, fly.io edge) can't pin a stale render alongside
+	// fresh long-cached static assets — a divergence that produces the
+	// "first paint missing styles, refresh fixes it" symptom class.
+	if got := resp.Header.Get("Cache-Control"); got != "no-cache, must-revalidate" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-cache, must-revalidate")
+	}
 }
 
 func TestServerNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Sets `Cache-Control: no-cache, must-revalidate` on HTML page responses so browsers and intermediate caches always re-validate the dynamic HTML against the server, instead of applying heuristic freshness from the absence of an explicit policy.

## Why

The docs site reproduced a class of bug where the **first paint after navigating between pages renders without layout styles applied** (sidebar shows inline with content, logo SVG renders at intrinsic ~300×150, body has no `margin-left` for the fixed sidebar). **A reload makes it correct.** That symptom shape — content from a recent build but with state that looks like an older render — is the canonical signature of a stale cached HTML being paired with fresh fingerprinted CSS/JS.

Without `Cache-Control` on HTML, browsers and CDNs use heuristic freshness lifetimes (often "10% of `Last-Modified` age", which can be hours). Static assets are already `public, max-age=31536000` because their URLs are content-fingerprinted, so the asset side is fine. The HTML side is the problem.

`no-cache` (not `no-store`) preserves the bfcache and ETag round-trip — the browser still keeps the HTML, but it always validates with the server before showing it. `must-revalidate` is the explicit "do not serve stale on a network failure" guarantee that some intermediate proxies need.

The reverse-proxy path (`routes: type: proxy`) is unaffected — proxied responses bypass `servePage` entirely and inherit the upstream's `Cache-Control`.

## Test plan

- [x] New assertion in `TestServerServeHTTP` pins `Cache-Control: no-cache, must-revalidate`
- [x] CI-scope full suite (`go test -race -tags=ci -skip='E2E|e2e' ./...`) green locally
- [ ] Post-merge: cut v0.1.17, repin docs Dockerfile, deploy, ask user to retry the original repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)