### PR TITLE
fix(server): explicit width/height on toolbar SVGs

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2403,7 +2403,7 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
     <div class="page-toolbar">
         <!-- Presentation Mode Toggle -->
         <button id="presentation-toggle" class="presentation-btn" title="Toggle presentation mode (F key)" aria-label="Toggle presentation mode">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <rect x="2" y="7" width="20" height="15" rx="2" ry="2"/>
                 <polyline points="17 2 12 7 7 2"/>
             </svg>
@@ -2412,7 +2412,7 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
         <!-- Theme Toggle -->
         <div class="theme-toggle">
             <button id="theme-light" title="Light theme" aria-label="Light theme">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"/>
                     <line x1="12" y1="1" x2="12" y2="3"/>
                     <line x1="12" y1="21" x2="12" y2="23"/>
@@ -2425,12 +2425,12 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
                 </svg>
             </button>
             <button id="theme-dark" title="Dark theme" aria-label="Dark theme">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
                 </svg>
             </button>
             <button id="theme-auto" title="Auto theme (system preference)" aria-label="Auto theme">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
                     <line x1="8" y1="21" x2="16" y2="21"/>
                     <line x1="12" y1="17" x2="12" y2="21"/>

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -157,6 +157,40 @@ This is a test page.`
 	if got := resp.Header.Get("Cache-Control"); got != "no-cache, must-revalidate" {
 		t.Errorf("Cache-Control = %q, want %q", got, "no-cache, must-revalidate")
 	}
+
+	// Every inline SVG in the page chrome must declare its rendered
+	// dimensions as HTML attributes (width="..." height="...") rather
+	// than relying solely on a CSS rule like `.theme-toggle button svg
+	// { width: 1.1rem }` to size them. Without explicit attributes,
+	// browsers render an SVG at its intrinsic ~300×150 default for the
+	// brief window between HTML parsing and the inline <style> block
+	// being applied — which manifests as a giant logo-blob covering
+	// the toolbar on first paint, only resolving on reload because by
+	// then the CSS is in cache and applies before paint. Pinning
+	// dimensions in markup makes the size correct from the first byte.
+	svgIdx := 0
+	for i := 0; i < len(body); {
+		open := strings.Index(body[i:], "<svg")
+		if open == -1 {
+			break
+		}
+		open += i
+		close := strings.Index(body[open:], ">")
+		if close == -1 {
+			break
+		}
+		tag := body[open : open+close+1]
+		i = open + close + 1
+		// Skip the body-content mermaid SVG, which carries its own
+		// explicit width/height (verified separately by mermaid tests).
+		if strings.Contains(tag, `id="container"`) {
+			continue
+		}
+		if !strings.Contains(tag, "width=") || !strings.Contains(tag, "height=") {
+			t.Errorf("SVG #%d in page chrome lacks width/height attributes — will render at intrinsic 300x150 before CSS applies. Tag: %s", svgIdx, tag)
+		}
+		svgIdx++
+	}
 }
 
 func TestServerNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

The presentation-toggle and three theme-toggle SVGs in the page chrome carry only a `viewBox` attribute. They get sized exclusively by the inline `<style>` rule `.theme-toggle button svg { width: 1.1rem }`. The hamburger toggle is the exception — it already declares `width=\"24\" height=\"24\"`.

Pinning explicit dimensions matches the hamburger and removes a real first-paint window where SVGs without `width`/`height` render at the browser's intrinsic ~300×150 default.

## Why

Reproduced today on iOS Safari hitting `https://livetemplate.fly.dev/` — first navigation to the page renders four giant blue icons stacked across the top of the toolbar; reload renders correctly. The screenshot is unmistakable: stacked rectangles + visible hamburger underneath = four unsized SVGs at default size.

Why reload \"fixes\" it: on the second load the inline `<style>` is warm enough that the CSS rule applies before paint. On cold load the body parses and SVGs render before the CSS rule has been applied — particularly when the page also pulls in three external `<link rel=\"stylesheet\">` files (`pico.css`, `tinkerdown-client.css`, `prism.css`) which can extend the CSS-application window.

The CSS rule still applies to handle hover/active state. The fix only ensures the first-paint dimensions are correct.

## Test plan

- [x] `TestServerServeHTTP` extended to walk every inline `<svg>` in the page chrome and assert both `width=` and `height=` attributes are present
- [x] CI-scope full suite (`go test -race -tags=ci -skip='E2E|e2e' ./...`) green locally
- [ ] Post-merge: cut v0.1.18, repin docs Dockerfile, deploy, confirm with user that first paint on iOS no longer shows the giant icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)