### PR TITLE
fix(client): page TOC items render vertically, not horizontally

### DIFF
--- a/client/src/core/page-toc.css
+++ b/client/src/core/page-toc.css
@@ -3,8 +3,17 @@
  * For on-page section navigation nested under current page in sidebar
  */
 
-/* Nested sub-navigation list */
+/* Nested sub-navigation list. The explicit display rules on the <ul>
+ * and <li> are necessary because this list lives inside a <nav> in the
+ * sidebar, and PicoCSS's `nav ul { display: flex }` /
+ * `nav li { display: inline-block }` defaults would otherwise lay the
+ * TOC entries out horizontally — packed across the sidebar width
+ * instead of stacked under the active page. The outer .nav-pages
+ * override (in the docs-site inline CSS) catches the parent <ul> but
+ * not this nested one, so this rule has to assert the same explicit
+ * fallback for the inner level. */
 .page-toc-list {
+  display: block;
   list-style: none;
   margin: 0.25rem 0 0.5rem 0;
   padding: 0;
@@ -18,6 +27,7 @@
 }
 
 .page-toc-item {
+  display: list-item;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary

The nested page-TOC list (`<ul class=\"page-toc-list\">` shown under the active page in the sidebar) was rendering items horizontally — packed across the sidebar in a flex row, wrapping into 2-3 columns instead of stacked. Reproduced on [/recipes/architecture-flow](https://livetemplate.fly.dev/recipes/architecture-flow): the TOC items \"The full flow at a glance\", \"1. The user interacts\", \"2. The server routes the action\", \"3. The state mutates\" laid out at increasing x-offsets.

## Root cause

Both `<ul>` and `<li>` for the page TOC live inside the sidebar `<nav>`. PicoCSS sets `nav ul { display: flex }` and `nav li { display: inline-block }` as global defaults. The `.nav-pages` overrides in the docs-site inline CSS catch the OUTER list (`.nav-pages` ul + `.nav-pages li`), but `page-toc.css` declared no `display` on the inner `.page-toc-list` / `.page-toc-item`, so Pico's defaults cascaded and won.

## Fix

Add the same defensive overrides on the nested level:

```css
.page-toc-list {
  display: block;       /* was implicit; Pico made it flex */
  ...
}
.page-toc-item {
  display: list-item;   /* was implicit; Pico made it inline-block */
  ...
}
```

## Test plan

- [x] Server suite green: `go test -race -tags=ci -skip='E2E|e2e' ./internal/server/`
- [x] Client CSS bundle rebuilt; verified `page-toc-list{display:block;...}` and `page-toc-item{display:list-item;...}` present in `dist/tinkerdown-client.browser.css`
- [ ] Post-merge: cut tinkerdown release, repin docs Dockerfile, redeploy, confirm sidebar TOC stacks vertically on `/recipes/architecture-flow`