### PR TITLE
fix(server): clip horizontal overflow on sidebar so it stops floating

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1649,6 +1649,15 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
              * value on overscroll-behavior keeps nav scroll from chaining
              * into the page when the sidebar reaches its end. */
             overflow-y: auto;
+            /* Per CSS spec, setting overflow-y to anything but `visible`
+             * makes the orthogonal axis behave as `auto` too. Without an
+             * explicit overflow-x, content that bleeds slightly past the
+             * sidebar's content box (e.g. PicoCSS's nav ul with negative
+             * horizontal margins, or any deeply-padded link) produces a
+             * tiny horizontal scrollbar — making the sidebar "float"
+             * horizontally during vertical scroll on touch devices. Hide
+             * horizontal overflow so the sidebar locks to its column. */
+            overflow-x: hidden;
             overscroll-behavior: contain;
         }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1649,14 +1649,14 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
              * value on overscroll-behavior keeps nav scroll from chaining
              * into the page when the sidebar reaches its end. */
             overflow-y: auto;
-            /* Per CSS spec, setting overflow-y to anything but `visible`
-             * makes the orthogonal axis behave as `auto` too. Without an
-             * explicit overflow-x, content that bleeds slightly past the
-             * sidebar's content box (e.g. PicoCSS's nav ul with negative
-             * horizontal margins, or any deeply-padded link) produces a
-             * tiny horizontal scrollbar — making the sidebar "float"
-             * horizontally during vertical scroll on touch devices. Hide
-             * horizontal overflow so the sidebar locks to its column. */
+            /* Per CSS spec, setting overflow-y to anything but visible
+             * makes the orthogonal axis behave as auto too. Without an
+             * explicit overflow-x, content that bleeds slightly past
+             * the sidebar's content box (e.g. PicoCSS's nav ul with
+             * negative horizontal margins) produces a tiny horizontal
+             * scrollbar — making the sidebar "float" horizontally
+             * during vertical scroll on touch devices. Clip to the
+             * sidebar's column. */
             overflow-x: hidden;
             overscroll-behavior: contain;
         }


### PR DESCRIPTION
## Summary

Sidebar was scrolling horizontally a few pixels on touch devices, making it visually float left/right during vertical page scroll. Reproduced via chromedp:

```
sidebar.scrollWidth: 373, clientWidth: 359  → 14px of horizontal overflow
sidebar.overflowX: auto                     → scrollbar appears
```

## Root cause

The sidebar declared only `overflow-y: auto`. Per the CSS spec, when one axis is anything but `visible`, the other axis behaves as `auto` too. Combined with PicoCSS's `nav ul` negative horizontal margins (which bleed the inner UL ~13px past its parent), the sidebar gained a tiny horizontal scrollbar that let users (or accidental touches) scroll it left/right.

## Fix

Add `overflow-x: hidden` to `.tinkerdown-nav-sidebar`. Vertical scroll still works (long nav lists scroll fine); any content bleed gets clipped to the sidebar's column.

## Test plan

- [x] Server suite green: `go test -race -tags=ci -skip='E2E|e2e' ./internal/server/`
- [ ] Post-merge: cut release, repin docs Dockerfile, redeploy, confirm sidebar no longer scrolls horizontally