### PR TITLE
chore: add CHANGELOG with v0.2.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Changelog
+
+All notable changes to tinkerdown will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Earlier releases (v0.1.x) are documented in the
+[GitHub releases page](https://github.com/livetemplate/tinkerdown/releases).
+
+
+## [v0.2.0] - 2026-05-07
+
+### Added — Literate authoring primitives
+
+A toolkit for documentation that *shows the real code, running*. Three
+composable primitives let an author pair source listings with live
+widgets without any drift between docs and production.
+
+#### `show-source` / `hide-source` flag on `lvt` blocks
+
+Add `show-source` to a fenced ` ```lvt ` block to render the template
+both as a syntax-highlighted listing and as the live, interactive
+widget it produces. Page-level default via `lvt_show_source: true`
+in frontmatter; individual blocks can opt out with `hide-source`.
+
+#### `embed-lvt` block
+
+Embeds a deployed LiveTemplate app inline. Tinkerdown fetches the
+upstream HTML server-side at render time so the page paints fully
+on first paint; the WebSocket attaches afterwards for live updates.
+
+Attributes:
+- `path=` — docs-side path to expose (default `/`)
+- `upstream=` — HTTP origin of the deployed app; auto-registers a
+  reverse-proxy from `path=` (no `tinkerdown.yaml` route entry needed)
+- `server=` — alternative cross-origin direct mode (no proxy);
+  remote app must include the docs origin in its `AllowedOrigins`
+- `session=` — authoring intent for linked widgets (real cross-region
+  state sharing comes from the upstream app's `BroadcastAction` calls
+  + a constant-groupID authenticator, not from this attribute)
+- `timeout=` — server-side fetch deadline (default `2s`)
+- `height=` — CSS `min-height` for layout stability
+- `show-source` — display upstream HTML alongside the live preview
+
+#### `include="..."` fence attribute
+
+Slices a real source file into a rendered code block:
+
+- `lines="N-M"` — single 1-indexed inclusive range; auto-clamps if the
+  file shrinks below the upper bound
+- `lines="N-M,P-Q"` — multiple ranges, joined with a language-aware
+  ellipsis comment (`// ...` for Go, `# ...` for Python/YAML,
+  `<!-- ... -->` for HTML, etc.)
+- `region="name"` — extracts content between
+  `// >>> region:name` / `// <<< region:name` markers; survives
+  line-number drift across edits
+- `highlight="N-M"` — Prism Line Highlight overlay; numbers are
+  file-absolute and match the rendered gutter
+
+#### Auto source-link footer
+
+Each `include=` block automatically renders a `counter.go:13-35`
+footer link to the cited file at the cited range. Activated by
+frontmatter:
+
+```yaml
+source_repo: https://github.com/yourorg/yourrepo
+source_path: examples/literate-counter/index.md
+```
+
+Default git ref tracks the running tinkerdown binary's release
+version (set via build-time ldflags); override per-page with
+`source_ref:`. For `dev` builds, the ref falls back to `main`. URL
+schemes are restricted to `http(s)://` to prevent XSS via author-set
+`javascript:` or `data:` URLs.
+
+#### Path confinement, dedent, and hot reload
+
+- Include paths are resolved relative to the markdown file's
+  directory, canonicalised (symlinks followed), and confined to
+  that tree. Escape attempts (`../../etc/passwd`) are rejected with
+  a warning; the page still renders.
+- The longest common leading whitespace across non-blank lines is
+  stripped, so a function-body slice renders flush-left without
+  mangling its relative indentation.
+- The file watcher tracks every included file via `SetExtraFiles`.
+  Editing `_app/counter.go` while the page is open auto-refreshes
+  the rendered snippet (and the source-link footer).
+- File-size cap (`maxIncludeBytes = 10 MB`) on `include=` reads
+  guards against accidentally pulling vendored binaries or large
+  logs into the docs build.
+
+#### Vendored Prism plugins
+
+Prism Line Numbers + Line Highlight are vendored from prismjs@1.29.0
+and loaded only on pages where `len(IncludedFiles) > 0`. Pages
+without source-includes pay zero asset cost.
+
+### Added — Reference examples
+
+- `examples/literate-counter/`, `examples/literate-linked/` —
+  `show-source` on inline `lvt` blocks bound to markdown data sources
+- `examples/literate-counter-include/` — `include=` slicing a real
+  `_app/counter.go` paired with `embed-lvt`; canonical A2 shape
+- `examples/literate-linked-include/` — A3 pattern: two `embed-lvt`
+  blocks sharing one upstream session via constant-groupID
+  authenticator + `BroadcastAction` in handlers
+- `examples/embed-counter/`, `examples/embed-shared-session/`,
+  `examples/mixed-tracks/` — embed-only and combined-tracks examples
+- In-tree authoring guide at `docs/guides/literate-docs.md` covering
+  `show-source`, `include=`, and pairing with `embed-lvt`
+
+### Fixed
+
+- Embed event-delegator collision when two `embed-lvt` blocks point
+  at the same upstream — wrapper IDs are now suffixed with the
+  per-block id so livetemplate's event delegator routes correctly to
+  each region.
+- CommonMark-compliant fence opener recognition in the include
+  preprocessor — `include=` fences inside lists and quotes are now
+  resolved (previously skipped).
+- Race in `isIncludedFile` watcher callback — acquire `s.mu.RLock`
+  around page-route iteration; short-circuit on `.md` events so
+  watcher doesn't redundantly scan the include set during Discover.
+
+[v0.2.0]: https://github.com/livetemplate/tinkerdown/compare/v0.1.20...v0.2.0


### PR DESCRIPTION
## Summary

Bootstraps `CHANGELOG.md` and adds the v0.2.0 release notes covering the literate-authoring toolkit shipped via #251 (which absorbed #256).

The release covers:
- `show-source` / `hide-source` flags on `lvt` blocks (+ `lvt_show_source` frontmatter)
- `embed-lvt` block with `path` / `upstream` / `server` / `session` / `timeout` / `height` / `show-source` attributes
- `include="..."` with `lines=` / `region=` / `highlight=` and auto source-link footer
- Path confinement, dedent, hot reload via `SetExtraFiles`
- Vendored Prism Line Numbers + Line Highlight plugins (gated on `len(IncludedFiles) > 0`)

After merge: `./release.sh 0.2.0` cuts the v0.2.0 tag, which unblocks the literate rehaul of `livetemplate/docs` (Phase 1 of the docs rehaul plan).

## Test plan

- [ ] PR diff is just `CHANGELOG.md` (no code changes — this is a release-prep PR)
- [ ] CI is skipped via `paths-ignore: ['**/*.md']` (expected, not a problem)
- [ ] CHANGELOG renders correctly on GitHub (headings, code fences, link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)