### PR TITLE
fix(source): make resolved exec cmd path absolute to avoid double-nesting

### DIFF
--- a/internal/source/exec.go
+++ b/internal/source/exec.go
@@ -98,12 +98,22 @@ func (s *ExecSource) Name() string {
 // cmd: "./script.sh" means "the script.sh next to my tinkerdown.yaml".
 // Bare names like 'curl' and absolute paths pass through unchanged so
 // PATH lookup still works as expected.
+//
+// The returned path is made absolute so that cmd.Dir's chdir does not
+// re-prefix it inside the child process. With cmd.Dir == siteDir, leaving
+// the result relative would cause the kernel to look up
+// 'siteDir/<joined>' relative to the post-chdir CWD, double-nesting the
+// prefix and producing ENOENT.
 func resolveCmdPath(cmdName, siteDir string) string {
 	if siteDir == "" {
 		return cmdName
 	}
 	if strings.HasPrefix(cmdName, "./") || strings.HasPrefix(cmdName, "../") {
-		return filepath.Join(siteDir, cmdName)
+		joined := filepath.Join(siteDir, cmdName)
+		if abs, err := filepath.Abs(joined); err == nil {
+			return abs
+		}
+		return joined
 	}
 	return cmdName
 }

--- a/internal/source/exec_test.go
+++ b/internal/source/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -459,4 +460,45 @@ func TestResolveCmdPath(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// Regression: a relative siteDir combined with cmd.Dir = siteDir caused execve
+// to double-nest the prefix (siteDir/siteDir/script.sh) after the child chdir.
+// resolveCmdPath must return an absolute path so cmd.Dir's chdir doesn't
+// re-prefix the path inside the child.
+func TestResolveCmdPath_RelativeSiteDir_ReturnsAbsolute(t *testing.T) {
+	got := resolveCmdPath("./script.sh", "examples/test")
+	assert.True(t, filepath.IsAbs(got), "expected absolute path, got: %s", got)
+	assert.True(t, strings.HasSuffix(got, filepath.Join("examples", "test", "script.sh")),
+		"expected suffix examples/test/script.sh, got: %s", got)
+}
+
+// Regression: end-to-end fetch with a relative siteDir must succeed. Before
+// the fix, this failed with `fork/exec examples/.../script.sh: no such file
+// or directory` because the resolved cmd.Path was relative and the child
+// chdir'd into siteDir before execve, double-nesting the prefix.
+func TestExecSourceFetch_RelativeSiteDir_DoesNotDoubleNest(t *testing.T) {
+	config.SetAllowExec(true)
+	defer config.SetAllowExec(false)
+
+	parent := t.TempDir()
+	siteDir := "site"
+	siteDirAbs := filepath.Join(parent, siteDir)
+	require.NoError(t, os.Mkdir(siteDirAbs, 0755))
+
+	scriptPath := filepath.Join(siteDirAbs, "data.sh")
+	scriptContent := `#!/usr/bin/env bash
+echo '[{"id":1,"name":"Alice"}]'
+`
+	require.NoError(t, os.WriteFile(scriptPath, []byte(scriptContent), 0755))
+
+	t.Chdir(parent)
+
+	src, err := NewExecSource("test", "./data.sh", siteDir)
+	require.NoError(t, err)
+
+	rows, err := src.Fetch(context.Background())
+	require.NoError(t, err, "relative siteDir + cmd.Dir = siteDir must not double-nest")
+	require.Len(t, rows, 1)
+	assert.Equal(t, float64(1), rows[0]["id"])
 }


### PR DESCRIPTION
## Summary

PR #244 prepended `siteDir` to `cmd.Path` while also setting `cmd.Dir = siteDir`. On Linux the order is `fork()` → child `chdir(cmd.Dir)` → child `execve(cmd.Path)`, so the still-relative `cmd.Path` was resolved AFTER the chdir, double-nesting the prefix:

- Before child chdir: CWD = `tinkerdown/`
- `chdir("examples/exec-toolbar-test")` → child CWD = `tinkerdown/examples/exec-toolbar-test`
- `execve("examples/exec-toolbar-test/get-info.sh")` → looks for `tinkerdown/examples/exec-toolbar-test/examples/exec-toolbar-test/get-info.sh` → ENOENT

The internal unit tests in PR #244 used absolute paths from `t.TempDir()`, so they didn't exhibit the bug. The livetemplate **Cross-Repository Tests** workflow uses relative `siteDir = "examples/exec-toolbar-test"` for E2E tests, and this has been failing every PR run since the v0.2.0 bump landed (May 4) — `TestExecToolbarManualMode`, `TestExecArgsForm`, `TestLvtSourceExec` all hit this path.

## Fix

`filepath.Abs()` the joined path inside `resolveCmdPath` so `cmd.Dir`'s chdir cannot re-prefix it inside the child. The original PR #244 intent (resolve `./` against `siteDir`, not process CWD) is preserved.

## Tests

- `TestResolveCmdPath_RelativeSiteDir_ReturnsAbsolute` — unit-level assertion that the helper returns `IsAbs()` output for a relative siteDir input.
- `TestExecSourceFetch_RelativeSiteDir_DoesNotDoubleNest` — full `Fetch` with a relative siteDir + `t.Chdir` + real script execution. This is the scenario the cross-repo E2E tests were failing on; would have caught PR #244 at unit level.

All 6 existing `TestResolveCmdPath` cases still pass (they use absolute siteDirs which `filepath.Abs` leaves unchanged).

## Test plan

- [x] `go test ./internal/source/...` — passes
- [x] All `TestResolveCmdPath` subcases preserved
- [x] New regression covers the actual e2e scenario
- [ ] Cross-repo workflow on a downstream livetemplate PR turns green for `Test Tinkerdown against Core Changes` once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)