### PR TITLE
feat(page): site-wide include root via ParseFileInSite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ Earlier releases (v0.1.x) are documented in the
 [GitHub releases page](https://github.com/livetemplate/tinkerdown/releases).
 
 
+## [v0.2.1] - 2026-05-09
+
+### Added — Site-wide include resolution
+
+`tinkerdown serve` now resolves `include="..."` paths against the
+**site root** (the content directory passed to `serve`) instead of
+each markdown file's own parent directory. Cross-page references like
+`include="../recipes/counter/_app/counter.go"` from a page in
+`getting-started/` now succeed; paths that escape the site root are
+still rejected.
+
+Library API:
+
+- New `tinkerdown.ParseFileInSite(path, siteRoot)` — uses `siteRoot`
+  as the include-confinement boundary. Pass `siteRoot=""` to fall
+  back to page-root confinement.
+- Existing `tinkerdown.ParseFile(path)` is unchanged — single-page
+  callers (CLI tools, library users rendering one .md file) keep the
+  v0.2.0 page-root-confined default.
+
+Motivation: the v1 page-root confinement (per the comment in
+`page.go:103-109` of v0.2.0) made it impossible for a multi-page docs
+site to maintain a single source of truth for code samples shared
+across pages. The classic case: a "Getting Started" tutorial and a
+"Recipes" deep-dive that both want to include from the same
+deployable `_app/`. Site-wide root resolution unblocks that without
+removing the security boundary — paths still must stay under the
+site directory.
+
+The `serve` and `validate` commands automatically use `ParseFileInSite`
+with the configured content directory; no per-page frontmatter is
+needed.
+
+
 ## [v0.2.0] - 2026-05-07
 
 ### Added — Literate authoring primitives
@@ -124,4 +158,5 @@ without source-includes pay zero asset cost.
   around page-route iteration; short-circuit on `.md` events so
   watcher doesn't redundantly scan the include set during Discover.
 
+[v0.2.1]: https://github.com/livetemplate/tinkerdown/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/livetemplate/tinkerdown/compare/v0.1.20...v0.2.0

--- a/cmd/tinkerdown/commands/validate.go
+++ b/cmd/tinkerdown/commands/validate.go
@@ -76,9 +76,7 @@ func ValidateCommand(args []string) error {
 
 		totalFiles++
 
-		// Validate the file by attempting to parse it. Use absDir as the
-		// site root so cross-page `include="../other-page/_app/..."`
-		// references validate the same way they resolve at serve time.
+		// Site root = absDir so cross-page includes validate as serve sees them.
 		_, err = tinkerdown.ParseFileInSite(path, absDir)
 		if err != nil {
 			// Collect error

--- a/cmd/tinkerdown/commands/validate.go
+++ b/cmd/tinkerdown/commands/validate.go
@@ -76,8 +76,10 @@ func ValidateCommand(args []string) error {
 
 		totalFiles++
 
-		// Validate the file by attempting to parse it
-		_, err = tinkerdown.ParseFile(path)
+		// Validate the file by attempting to parse it. Use absDir as the
+		// site root so cross-page `include="../other-page/_app/..."`
+		// references validate the same way they resolve at serve time.
+		_, err = tinkerdown.ParseFileInSite(path, absDir)
 		if err != nil {
 			// Collect error
 			fileErrors = append(fileErrors, fileValidationError{

--- a/internal/include/include.go
+++ b/internal/include/include.go
@@ -440,7 +440,7 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 
 	rel, err := filepath.Rel(resolvedRoot, resolvedCandidate)
 	if err != nil || strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("include %q escapes the page root", includePath)
+		return "", fmt.Errorf("include %q escapes the include root", includePath)
 	}
 	return resolvedCandidate, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -283,7 +283,7 @@ func (s *Server) Discover() error {
 		pattern := mdToPattern(relPath)
 
 		// Parse the page
-		page, err := tinkerdown.ParseFile(path)
+		page, err := tinkerdown.ParseFileInSite(path, s.rootDir)
 		if err != nil {
 			log.Printf("Warning: Failed to parse %s: %v", relPath, err)
 			return nil // Continue with other files

--- a/internal/site/manager.go
+++ b/internal/site/manager.go
@@ -70,7 +70,7 @@ func (m *Manager) discoverFromConfig() error {
 			absPath := filepath.Join(m.rootDir, filePath)
 
 			// Parse the page
-			parsed, err := tinkerdown.ParseFile(absPath)
+			parsed, err := tinkerdown.ParseFileInSite(absPath, m.rootDir)
 			if err != nil {
 				return fmt.Errorf("failed to parse %s: %w", filePath, err)
 			}
@@ -103,7 +103,7 @@ func (m *Manager) discoverFromConfig() error {
 		homePath := m.config.Site.Home
 		absPath := filepath.Join(m.rootDir, homePath)
 
-		parsed, err := tinkerdown.ParseFile(absPath)
+		parsed, err := tinkerdown.ParseFileInSite(absPath, m.rootDir)
 		if err != nil {
 			return fmt.Errorf("failed to parse home page %s: %w", homePath, err)
 		}
@@ -163,7 +163,7 @@ func (m *Manager) discoverFromFiles() error {
 		}
 
 		// Parse the page
-		parsed, err := tinkerdown.ParseFile(path)
+		parsed, err := tinkerdown.ParseFileInSite(path, m.rootDir)
 		if err != nil {
 			return fmt.Errorf("failed to parse %s: %w", relPath, err)
 		}
@@ -389,7 +389,7 @@ func (m *Manager) Reload(filePath string) error {
 	}
 
 	// Re-parse the file
-	parsed, err := tinkerdown.ParseFile(filePath)
+	parsed, err := tinkerdown.ParseFileInSite(filePath, m.rootDir)
 	if err != nil {
 		return fmt.Errorf("failed to parse %s: %w", relPath, err)
 	}

--- a/page.go
+++ b/page.go
@@ -62,31 +62,37 @@ func ParseFile(path string) (*Page, error) {
 // If siteRoot is empty, behaves identically to ParseFile (no
 // path-under-root check).
 func ParseFileInSite(path, siteRoot string) (*Page, error) {
-	if siteRoot != "" {
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			return nil, fmt.Errorf("resolve path %q: %w", path, err)
-		}
-		absRoot, err := filepath.Abs(siteRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve siteRoot %q: %w", siteRoot, err)
-		}
-		// Symlink-canonicalise both before the prefix check so a
-		// symlinked tempdir (e.g. macOS /tmp → /private/tmp) doesn't
-		// false-positive as outside-the-root. Same trick include.Resolve
-		// uses for include candidates.
-		if r, err := filepath.EvalSymlinks(absPath); err == nil {
-			absPath = r
-		}
-		if r, err := filepath.EvalSymlinks(absRoot); err == nil {
-			absRoot = r
-		}
-		rel, err := filepath.Rel(absRoot, absPath)
-		if err != nil || strings.HasPrefix(rel, "..") {
-			return nil, fmt.Errorf("path %q is not under siteRoot %q", path, siteRoot)
-		}
+	if siteRoot == "" {
+		return parseFile(path, "")
 	}
-	return parseFile(path, siteRoot)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve path %q: %w", path, err)
+	}
+	absRoot, err := filepath.Abs(siteRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve siteRoot %q: %w", siteRoot, err)
+	}
+	// Symlink-canonicalise both before the prefix check so a
+	// symlinked tempdir (e.g. macOS /tmp → /private/tmp) doesn't
+	// false-positive as outside-the-root. Same trick include.Resolve
+	// uses for include candidates.
+	if r, err := filepath.EvalSymlinks(absPath); err == nil {
+		absPath = r
+	}
+	if r, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = r
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return nil, fmt.Errorf("path %q is not under siteRoot %q", path, siteRoot)
+	}
+	// Thread the resolved absolute root (not the caller's raw value) so a
+	// relative siteRoot like "./site" reaches include.Resolve already
+	// canonicalised — otherwise a relative root could pass the precondition
+	// check above (which uses absRoot internally) but misbehave during
+	// per-include resolution.
+	return parseFile(path, absRoot)
 }
 
 func parseFile(path, siteRoot string) (*Page, error) {

--- a/page.go
+++ b/page.go
@@ -87,12 +87,9 @@ func ParseFileInSite(path, siteRoot string) (*Page, error) {
 	if err != nil || strings.HasPrefix(rel, "..") {
 		return nil, fmt.Errorf("path %q is not under siteRoot %q", path, siteRoot)
 	}
-	// Thread the resolved absolute root (not the caller's raw value) so a
-	// relative siteRoot like "./site" reaches include.Resolve already
-	// canonicalised — otherwise a relative root could pass the precondition
-	// check above (which uses absRoot internally) but misbehave during
-	// per-include resolution.
-	return parseFile(path, absRoot)
+	// Threading absRoot (not raw siteRoot) so relative inputs like
+	// "./site" reach include.Resolve already canonicalised.
+	return parseFile(absPath, absRoot)
 }
 
 func parseFile(path, siteRoot string) (*Page, error) {
@@ -161,12 +158,8 @@ func parseFile(path, siteRoot string) (*Page, error) {
 	}
 	var includedFiles []string
 	var includeWarnings []string
-	// includeRoot defaults to the markdown file's own directory (single-
-	// page mode, library callers). When siteRoot is provided (multi-page
-	// site), the root widens to the whole site so cross-page refs like
-	// `../recipes/foo/_app/x.go` resolve. Paths that escape includeRoot
-	// are still rejected — this is a widening, not a removal of the
-	// confinement check.
+	// Empty siteRoot keeps the v1 page-root confinement; non-empty widens
+	// to the whole site without removing the boundary.
 	includeRoot := includeBaseDir
 	if siteRoot != "" {
 		includeRoot = siteRoot

--- a/page.go
+++ b/page.go
@@ -31,8 +31,34 @@ var (
 	listDetectRegex   = regexp.MustCompile(`(?i)<(ul|ol)[^>]*lvt-source=`)
 )
 
-// ParseFile parses a markdown file and creates a Page.
+// ParseFile parses a markdown file and creates a Page. Includes
+// (`include="..."` fence attributes) are confined to the markdown
+// file's own directory tree.
+//
+// To allow includes to reach files elsewhere within a site (e.g. a
+// recipes/ page citing a shared `_app/` directory), use
+// ParseFileInSite — which widens the include-confinement root to the
+// site directory while still rejecting paths that escape it.
 func ParseFile(path string) (*Page, error) {
+	return parseFile(path, "")
+}
+
+// ParseFileInSite parses a markdown file as part of a multi-page site
+// rooted at siteRoot. Includes (`include="..."`) may reference files
+// anywhere within siteRoot, not just the page's own directory subtree;
+// paths that would escape siteRoot are still rejected.
+//
+// This is the entry point used by `tinkerdown serve` so cross-page
+// references like include="../recipes/counter/_app/counter.go" resolve
+// correctly. Library callers that don't want the wider scope (e.g.
+// rendering a single standalone .md file) should use ParseFile.
+//
+// If siteRoot is empty, behaves identically to ParseFile.
+func ParseFileInSite(path, siteRoot string) (*Page, error) {
+	return parseFile(path, siteRoot)
+}
+
+func parseFile(path, siteRoot string) (*Page, error) {
 	// Read file
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -63,9 +89,7 @@ func ParseFile(path string) (*Page, error) {
 
 	// Pre-process: substitute `include="..." lines="..."` fence bodies
 	// with the resolved file slice, so goldmark renders a regular code
-	// block with the included content. v1 confines includes to the
-	// markdown file's parent directory tree — sibling layouts (a
-	// shared snippet folder up the tree) are an additive feature.
+	// block with the included content.
 	//
 	// Pull `source_repo` + `source_path` from the page's frontmatter
 	// (lightweight pre-parse — same trick auto-tables uses) so each
@@ -100,14 +124,17 @@ func ParseFile(path string) (*Page, error) {
 	}
 	var includedFiles []string
 	var includeWarnings []string
-	// baseDir == root is intentional in v1: includes are confined to the
-	// markdown file's own directory tree, not the broader site root. This
-	// keeps each page self-contained — moving a page also moves anything
-	// it cites — and avoids ambiguous "../../some-other-page/snippet"
-	// references whose meaning would change with site layout. Widening
-	// `root` to the discovery root is a future option if a clear use case
-	// emerges, but the call site is the place to track that decision.
-	processedContent, includedFiles, includeWarnings = include.PreprocessWithLinks(processedContent, includeBaseDir, includeBaseDir, linkOpts)
+	// includeRoot defaults to the markdown file's own directory (single-
+	// page mode, library callers). When siteRoot is provided (multi-page
+	// site), the root widens to the whole site so cross-page refs like
+	// `../recipes/foo/_app/x.go` resolve. Paths that escape includeRoot
+	// are still rejected — this is a widening, not a removal of the
+	// confinement check.
+	includeRoot := includeBaseDir
+	if siteRoot != "" {
+		includeRoot = siteRoot
+	}
+	processedContent, includedFiles, includeWarnings = include.PreprocessWithLinks(processedContent, includeBaseDir, includeRoot, linkOpts)
 	for _, w := range includeWarnings {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}

--- a/page.go
+++ b/page.go
@@ -48,13 +48,44 @@ func ParseFile(path string) (*Page, error) {
 // anywhere within siteRoot, not just the page's own directory subtree;
 // paths that would escape siteRoot are still rejected.
 //
+// `path` must be located within siteRoot (otherwise every include —
+// including local ones in the page's own directory — would fail
+// confinement against a root that isn't an ancestor of the page). This
+// is enforced upfront with a clear error rather than producing
+// confusing per-include warnings later.
+//
 // This is the entry point used by `tinkerdown serve` so cross-page
 // references like include="../recipes/counter/_app/counter.go" resolve
 // correctly. Library callers that don't want the wider scope (e.g.
 // rendering a single standalone .md file) should use ParseFile.
 //
-// If siteRoot is empty, behaves identically to ParseFile.
+// If siteRoot is empty, behaves identically to ParseFile (no
+// path-under-root check).
 func ParseFileInSite(path, siteRoot string) (*Page, error) {
+	if siteRoot != "" {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("resolve path %q: %w", path, err)
+		}
+		absRoot, err := filepath.Abs(siteRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve siteRoot %q: %w", siteRoot, err)
+		}
+		// Symlink-canonicalise both before the prefix check so a
+		// symlinked tempdir (e.g. macOS /tmp → /private/tmp) doesn't
+		// false-positive as outside-the-root. Same trick include.Resolve
+		// uses for include candidates.
+		if r, err := filepath.EvalSymlinks(absPath); err == nil {
+			absPath = r
+		}
+		if r, err := filepath.EvalSymlinks(absRoot); err == nil {
+			absRoot = r
+		}
+		rel, err := filepath.Rel(absRoot, absPath)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return nil, fmt.Errorf("path %q is not under siteRoot %q", path, siteRoot)
+		}
+	}
 	return parseFile(path, siteRoot)
 }
 

--- a/page_test.go
+++ b/page_test.go
@@ -310,13 +310,41 @@ func TestParseFileInSite_PageRootConfinementByDefault(t *testing.T) {
 
 	// ParseFile (legacy entry point) — page-root confined, the include
 	// fails (warning logged), block renders empty/passthrough. We assert
-	// the snippet content is NOT present in the rendered HTML.
+	// the page DID render (heading present) AND the snippet content is
+	// NOT present — without the heading check, an empty StaticHTML
+	// would falsely pass.
 	page, err := ParseFile(pageMD)
 	if err != nil {
 		t.Fatalf("ParseFile error: %v", err)
 	}
-	if got := page.StaticHTML; got != "" && strings.Contains(got, "package x") {
+	if !strings.Contains(page.StaticHTML, "Page A") {
+		t.Fatalf("expected page to render its heading, got empty/missing StaticHTML: %q", page.StaticHTML)
+	}
+	if strings.Contains(page.StaticHTML, "package x") {
 		t.Errorf("ParseFile should reject ../ include via page-root confinement; rendered HTML contained 'package x'")
+	}
+}
+
+func TestParseFileInSite_RejectsPathOutsideSiteRoot(t *testing.T) {
+	// ParseFileInSite enforces an explicit precondition: the markdown
+	// path must be located within siteRoot. Otherwise every include —
+	// even a local `include="snippet.go"` in the page's own directory —
+	// would silently fail confinement against a root that isn't the
+	// page's ancestor. Better to fail fast with a clear error than
+	// produce confusing per-include warnings.
+	pageOutside := t.TempDir() // outside any site
+	siteRoot := t.TempDir()    // separate tree
+	pageMD := filepath.Join(pageOutside, "stranded.md")
+	if err := os.WriteFile(pageMD, []byte("# Stranded\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseFileInSite(pageMD, siteRoot)
+	if err == nil {
+		t.Fatalf("expected error when path is not under siteRoot; got nil")
+	}
+	if !strings.Contains(err.Error(), "not under siteRoot") {
+		t.Errorf("expected 'not under siteRoot' in error; got: %v", err)
 	}
 }
 

--- a/page_test.go
+++ b/page_test.go
@@ -465,14 +465,9 @@ func TestParseFileInSite_AcceptsRelativeSiteRoot(t *testing.T) {
 	}
 
 	// Switch into siteDir's parent so we can pass a relative siteRoot.
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
-	if err := os.Chdir(filepath.Dir(siteDir)); err != nil {
-		t.Fatal(err)
-	}
+	// t.Chdir restores the working dir automatically and signals to Go's
+	// test runner that this test isn't safe to t.Parallel().
+	t.Chdir(filepath.Dir(siteDir))
 	relRoot := "./" + filepath.Base(siteDir)
 
 	page, err := ParseFileInSite(pageMD, relRoot)

--- a/page_test.go
+++ b/page_test.go
@@ -3,6 +3,7 @@ package tinkerdown
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -282,5 +283,131 @@ steps: 5
 				t.Errorf("StepCount = %d, want %d", page.Config.StepCount, tt.wantSteps)
 			}
 		})
+	}
+}
+
+func TestParseFileInSite_PageRootConfinementByDefault(t *testing.T) {
+	// ParseFile (no siteRoot) preserves the v1 behavior: includes are
+	// confined to the markdown's own directory subtree. A `../` include
+	// pointing at a sibling page's _app/ is rejected.
+	siteDir := t.TempDir()
+	pageA := filepath.Join(siteDir, "pageA")
+	pageB := filepath.Join(siteDir, "pageB", "_app")
+	if err := os.MkdirAll(pageA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pageB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pageB, "snippet.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pageContent := "# Page A\n\n```go include=\"../pageB/_app/snippet.go\"\n```\n"
+	pageMD := filepath.Join(pageA, "index.md")
+	if err := os.WriteFile(pageMD, []byte(pageContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// ParseFile (legacy entry point) — page-root confined, the include
+	// fails (warning logged), block renders empty/passthrough. We assert
+	// the snippet content is NOT present in the rendered HTML.
+	page, err := ParseFile(pageMD)
+	if err != nil {
+		t.Fatalf("ParseFile error: %v", err)
+	}
+	if got := page.StaticHTML; got != "" && strings.Contains(got, "package x") {
+		t.Errorf("ParseFile should reject ../ include via page-root confinement; rendered HTML contained 'package x'")
+	}
+}
+
+func TestParseFileInSite_AllowsSiblingPageIncludes(t *testing.T) {
+	// ParseFileInSite (with siteRoot) widens confinement to the whole
+	// site, so a page can include from a sibling page's _app/ — exactly
+	// what livetemplate/docs needs for /getting-started/your-first-app
+	// to cite /recipes/counter/_app/counter.go.
+	siteDir := t.TempDir()
+	pageA := filepath.Join(siteDir, "pageA")
+	pageB := filepath.Join(siteDir, "pageB", "_app")
+	if err := os.MkdirAll(pageA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pageB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pageB, "snippet.go"), []byte("package x\n// sentinel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pageMD := filepath.Join(pageA, "index.md")
+	if err := os.WriteFile(pageMD, []byte("# Page A\n\n```go include=\"../pageB/_app/snippet.go\"\n```\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := ParseFileInSite(pageMD, siteDir)
+	if err != nil {
+		t.Fatalf("ParseFileInSite error: %v", err)
+	}
+	if !strings.Contains(page.StaticHTML, "// sentinel") {
+		t.Errorf("ParseFileInSite should resolve ../ include into siteRoot; rendered HTML missing snippet content. Got:\n%s", page.StaticHTML)
+	}
+}
+
+func TestParseFileInSite_RejectsPathsEscapingSiteRoot(t *testing.T) {
+	// Confinement still applies — a page cannot reach outside siteRoot
+	// even when ParseFileInSite is used. siteRoot is the boundary, not
+	// a removed check.
+	siteDir := t.TempDir()
+	outside := t.TempDir() // separate tree; will not be under siteDir
+	if err := os.WriteFile(filepath.Join(outside, "secret.go"), []byte("package secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pageDir := filepath.Join(siteDir, "page")
+	if err := os.MkdirAll(pageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pageMD := filepath.Join(pageDir, "index.md")
+	rel, err := filepath.Rel(pageDir, filepath.Join(outside, "secret.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pageMD, []byte("# X\n\n```go include=\""+rel+"\"\n```\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := ParseFileInSite(pageMD, siteDir)
+	if err != nil {
+		t.Fatalf("ParseFileInSite error: %v", err)
+	}
+	if strings.Contains(page.StaticHTML, "package secret") {
+		t.Errorf("ParseFileInSite should reject path escaping siteRoot; rendered HTML contained leaked content")
+	}
+}
+
+func TestParseFileInSite_EmptySiteRootBehavesLikeParseFile(t *testing.T) {
+	// Documents the public-API guarantee: passing siteRoot="" is
+	// equivalent to calling ParseFile. Lets callers pass through a
+	// configured-or-empty value without branching.
+	siteDir := t.TempDir()
+	pageA := filepath.Join(siteDir, "pageA")
+	pageB := filepath.Join(siteDir, "pageB", "_app")
+	if err := os.MkdirAll(pageA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pageB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pageB, "snippet.go"), []byte("package x\n// sentinel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pageMD := filepath.Join(pageA, "index.md")
+	if err := os.WriteFile(pageMD, []byte("# A\n\n```go include=\"../pageB/_app/snippet.go\"\n```\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := ParseFileInSite(pageMD, "")
+	if err != nil {
+		t.Fatalf("ParseFileInSite(empty siteRoot) error: %v", err)
+	}
+	if strings.Contains(page.StaticHTML, "// sentinel") {
+		t.Errorf("ParseFileInSite with empty siteRoot should fall back to page-root confinement; cross-page include leaked through")
 	}
 }

--- a/page_test.go
+++ b/page_test.go
@@ -439,3 +439,47 @@ func TestParseFileInSite_EmptySiteRootBehavesLikeParseFile(t *testing.T) {
 		t.Errorf("ParseFileInSite with empty siteRoot should fall back to page-root confinement; cross-page include leaked through")
 	}
 }
+
+func TestParseFileInSite_AcceptsRelativeSiteRoot(t *testing.T) {
+	// A relative siteRoot like "./site" must work the same as the
+	// equivalent absolute path. ParseFileInSite canonicalises siteRoot
+	// before threading it to the include resolver — otherwise a relative
+	// root would pass the precondition check (which uses an absolute
+	// copy internally) but fail or misbehave during per-include
+	// resolution where include.Resolve compares paths.
+	siteDir := t.TempDir()
+	pageA := filepath.Join(siteDir, "pageA")
+	pageB := filepath.Join(siteDir, "pageB", "_app")
+	if err := os.MkdirAll(pageA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pageB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pageB, "snippet.go"), []byte("package x\n// sentinel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pageMD := filepath.Join(pageA, "index.md")
+	if err := os.WriteFile(pageMD, []byte("# A\n\n```go include=\"../pageB/_app/snippet.go\"\n```\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Switch into siteDir's parent so we can pass a relative siteRoot.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Dir(siteDir)); err != nil {
+		t.Fatal(err)
+	}
+	relRoot := "./" + filepath.Base(siteDir)
+
+	page, err := ParseFileInSite(pageMD, relRoot)
+	if err != nil {
+		t.Fatalf("ParseFileInSite(relative siteRoot) error: %v", err)
+	}
+	if !strings.Contains(page.StaticHTML, "// sentinel") {
+		t.Errorf("relative siteRoot should resolve to abs path; rendered HTML missing snippet content")
+	}
+}


### PR DESCRIPTION
## Summary

Widens the include-resolution root from per-page directory to a configurable site root, so multi-page sites can share a single source-of-truth across pages via `include="..."`.

The v0.2.0 comment at \`page.go:103-109\` explicitly deferred this until "a clear use case emerges." The clear use case is now: livetemplate/docs has both \`/getting-started/your-first-app\` (the from-scratch tutorial) and \`/recipes/counter\` (the deeper recipe), both wanting to slice from the same canonical \`_app/counter/\`. Without site-wide root, they have to duplicate code or one has to give up literate authoring.

## Public API (additive only)

- **NEW** \`tinkerdown.ParseFileInSite(path, siteRoot string) (*Page, error)\` — uses \`siteRoot\` as the include-confinement boundary. Cross-page \`../\` includes resolve as long as they stay under \`siteRoot\`.
- **UNCHANGED** \`tinkerdown.ParseFile(path) (*Page, error)\` — backward compatible. Single-page callers (CLI \`build\`, \`fix\`, library users rendering one .md file) keep the v0.2.0 page-root-confined default.
- \`ParseFileInSite(path, "")\` falls back to \`ParseFile\` semantics so callers can pass through a configured-or-empty value without branching.

## Internal updates

- \`internal/server/server.go\` and \`internal/site/manager.go\` switch their 5 \`ParseFile\` call sites to \`ParseFileInSite\` passing the server/manager \`rootDir\`. Result: \`tinkerdown serve\` and \`tinkerdown validate\` automatically use site-wide include resolution; no per-page frontmatter knob needed.

## Tests (page_test.go, +127 LOC, all pass)

- \`PageRootConfinementByDefault\` — \`ParseFile\` keeps v0.2.0 behavior; \`../\` includes still rejected
- \`AllowsSiblingPageIncludes\` — \`ParseFileInSite\` resolves \`../pageB/_app/snippet.go\` when both share \`siteRoot\`
- \`RejectsPathsEscapingSiteRoot\` — confinement still applies; widening, not removal
- \`EmptySiteRootBehavesLikeParseFile\` — semantics documented

## Verified end-to-end

Against livetemplate/docs's PR-B worktree:
- \`/getting-started/your-first-app\` and \`/recipes/counter/\` both HTTP 200
- \`include="../recipes/counter/_app/counter.go"\` from your-first-app renders the actual file content (verified via grep for new comment text)
- Zero "escapes the page root" warnings in the serve log

## Test plan

- [x] \`go test ./...\` (non-e2e) — all pass; e2e timeouts are pre-existing
- [x] \`go vet ./...\` clean
- [x] Built locally + ran against docs.recipes-counter-deeper worktree — both pages render correctly with site-wide includes
- [ ] CI green
- [ ] Release v0.2.1 after merge

## Heads-up

Once merged + tagged v0.2.1, livetemplate/docs's Dockerfile bumps \`TINKERDOWN_REF\` from v0.2.0 → v0.2.1 to unblock PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)