### PR TITLE
docs(readme): weave literate authoring into "What You Can Build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The same primitive scales to other artifacts:
 ```
 `````
 
+A literate doc in the wild: **[livetemplate.fly.dev/recipes/counter](https://livetemplate.fly.dev/recipes/counter/)** — prose, source listings, and a live counter on one page, all from a single markdown file.
+
 See the [Literate Authoring guide](docs/guides/literate-docs.md) for the full primitive set (line ranges, named regions, line highlights, source-link footers) and [examples/literate-counter-include](examples/literate-counter-include) for the canonical pattern.
 
 **Need more control?** Tinkerdown has five complexity tiers. Each builds on the previous — nothing rewrites; start at the lowest tier that works:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The same primitive scales to other artifacts:
 | Artifact | What it looks like |
 |---|---|
 | **Dashboard / status report** | Frontmatter pulls from PostgreSQL or REST; tables, computed totals, and Mermaid diagrams render inline. ([examples/markdown-data-dashboard](examples/markdown-data-dashboard)) |
-| **Literate doc / runnable explainer** | Prose alongside live widgets, real source files cited by line range, and your deployed app embedded inline — the doc *is* the working code. See [Literate Authoring](docs/guides/literate-docs.md). ([examples/literate-counter-include](examples/literate-counter-include)) |
+| **Literate doc / runnable explainer** | Prose alongside live widgets, real source cited by line range, and your deployed app embedded inline — the doc *is* the working code. ([Literate Authoring guide](docs/guides/literate-docs.md), [examples/literate-counter-include](examples/literate-counter-include)) |
 | **Triage / standup board** | Action buttons mutate a shared SQLite or PostgreSQL source; every teammate's tab stays in sync over WebSocket. ([examples/standup-bot](examples/standup-bot), [examples/team-tasks](examples/team-tasks)) |
 | **Throwaway admin panel** | Point at a table you already have. Edit/delete/add for free. ([examples/auto-table-sqlite](examples/auto-table-sqlite)) |
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,24 @@ The same primitive scales to other artifacts:
 | Artifact | What it looks like |
 |---|---|
 | **Dashboard / status report** | Frontmatter pulls from PostgreSQL or REST; tables, computed totals, and Mermaid diagrams render inline. ([examples/markdown-data-dashboard](examples/markdown-data-dashboard)) |
-| **Interactive explainer** | Prose + live `lvt` code blocks + show-source listings, so the doc *is* the working demo. ([examples/literate-counter](examples/literate-counter)) |
+| **Literate doc / runnable explainer** | Prose alongside live widgets, real source files cited by line range, and your deployed app embedded inline — the doc *is* the working code. See [Literate Authoring](docs/guides/literate-docs.md). ([examples/literate-counter-include](examples/literate-counter-include)) |
 | **Triage / standup board** | Action buttons mutate a shared SQLite or PostgreSQL source; every teammate's tab stays in sync over WebSocket. ([examples/standup-bot](examples/standup-bot), [examples/team-tasks](examples/team-tasks)) |
 | **Throwaway admin panel** | Point at a table you already have. Edit/delete/add for free. ([examples/auto-table-sqlite](examples/auto-table-sqlite)) |
+
+**Literate authoring.** When the page itself is a tutorial, the same markdown can show real source *and* run it. Cite line ranges from your deployed `.go` / `.tmpl` files with `include=`, render templates next to their highlighted source with `show-source`, and drop in the running app with `embed-lvt` — no copy-pasted snippets to drift out of date.
+
+`````markdown
+```go include="./_app/counter.go" lines="5-8"
+```
+
+```go include="./_app/counter.go" lines="13-35" highlight="20"
+```
+
+```embed-lvt path="/apps/counter/" upstream="http://127.0.0.1:9090"
+```
+`````
+
+See the [Literate Authoring guide](docs/guides/literate-docs.md) for the full primitive set (line ranges, named regions, line highlights, source-link footers) and [examples/literate-counter-include](examples/literate-counter-include) for the canonical pattern.
 
 **Need more control?** Tinkerdown has five complexity tiers. Each builds on the previous — nothing rewrites; start at the lowest tier that works:
 
@@ -241,6 +256,7 @@ See [AI Generation Guide](docs/guides/ai-generation.md) for tips on Claude Code,
 - [Auto-Rendering](docs/guides/auto-rendering.md)
 - [Go Templates](docs/guides/go-templates.md)
 - [AI Generation](docs/guides/ai-generation.md)
+- [Literate Authoring](docs/guides/literate-docs.md)
 
 **Reference:**
 - [CLI Commands](docs/reference/cli.md)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The same primitive scales to other artifacts:
 | **Triage / standup board** | Action buttons mutate a shared SQLite or PostgreSQL source; every teammate's tab stays in sync over WebSocket. ([examples/standup-bot](examples/standup-bot), [examples/team-tasks](examples/team-tasks)) |
 | **Throwaway admin panel** | Point at a table you already have. Edit/delete/add for free. ([examples/auto-table-sqlite](examples/auto-table-sqlite)) |
 
-**Literate authoring.** When the page itself is a tutorial, the same markdown can show real source *and* run it. Cite line ranges from your deployed `.go` / `.tmpl` files with `include=`, render templates next to their highlighted source with `show-source`, and drop in the running app with `embed-lvt` — no copy-pasted snippets to drift out of date.
+**Literate authoring.** When the page itself is a tutorial, the same markdown can show real source *and* run it. Three primitives compose freely: `include=` cites line ranges from your deployed `.go` / `.tmpl` files, `show-source` pairs an inline ` ```lvt ` block with its highlighted template, and `embed-lvt` drops the running app inline. No copy-pasted snippets to drift out of date.
 
 `````markdown
 ```go include="./_app/counter.go" lines="5-8"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The same primitive scales to other artifacts:
 | **Triage / standup board** | Action buttons mutate a shared SQLite or PostgreSQL source; every teammate's tab stays in sync over WebSocket. ([examples/standup-bot](examples/standup-bot), [examples/team-tasks](examples/team-tasks)) |
 | **Throwaway admin panel** | Point at a table you already have. Edit/delete/add for free. ([examples/auto-table-sqlite](examples/auto-table-sqlite)) |
 
-**Literate authoring.** When the page itself is a tutorial, the same markdown can show real source *and* run it. Three primitives compose freely: `include=` cites line ranges from your deployed `.go` / `.tmpl` files, `show-source` pairs an inline ` ```lvt ` block with its highlighted template, and `embed-lvt` drops the running app inline. No copy-pasted snippets to drift out of date.
+**Literate authoring.** When the page itself is a tutorial, the same markdown can show real source *and* run it. The snippet below shows two of the three primitives: `include=` cites line ranges from your `.go` / `.tmpl` source files, and `embed-lvt` drops the running app inline. The third — `show-source` — pairs an inline ` ```lvt ` block with its highlighted template. No copy-pasted snippets to drift out of date.
 
 `````markdown
 ```go include="./_app/counter.go" lines="5-8"


### PR DESCRIPTION
## Summary

- v0.2.0 shipped **literate authoring** (`show-source`, `include=`, `embed-lvt`) but the main README only acknowledged it obliquely in one table cell, and the [Literate Authoring guide](docs/guides/literate-docs.md) was unreachable from the README.
- Three small, row-adjacent edits to `README.md` — no new top-level sections, no reframing of the headline thesis.
- The combined code snippet mirrors the **shape** of `examples/literate-counter-include/index.md` (state via `lines="5-8"`, handlers via `lines="13-35" highlight="20"`, then `embed-lvt`); the canonical example also includes a template fence, but the README snippet keeps it to three fences for compactness.

### What changed in `README.md`

1. **Artifacts table row** — "Interactive explainer" → "Literate doc / runnable explainer". Copy now names line-range citations + inline app embedding. Example link switches from `literate-counter` (only `show-source`) to `literate-counter-include` (all three primitives).
2. **New "Literate authoring" beat** after the table — one paragraph naming each primitive's job, a 3-fence combined snippet (state, handlers, `embed-lvt`), a one-line callout to the live recipe page, and links to the guide and example.
3. **Guides list** — adds `Literate Authoring` so the dedicated guide is finally reachable.

### What this PR deliberately does NOT do

- No edits to the "Why Tinkerdown" pillar list.
- No edits to the headline tagline.
- No changes to the five-tier complexity ladder — literate authoring is an authoring overlay orthogonal to the tiers, not another tier.
- No new screenshots or assets.
- No `CHANGELOG.md` change — v0.2.0 already documents the feature thoroughly; this PR is a discoverability fix, not a release note.

## Test plan

- [x] `git diff README.md` shows only the intended edits, no whitespace churn
- [x] All link targets exist (`docs/guides/literate-docs.md`, `examples/literate-counter-include/`, `https://livetemplate.fly.dev/recipes/counter/`)
- [x] `go test -tags=ci ./...` passes (project's CI mode that excludes chromedp e2e tests via `//go:build !ci`)
- [x] **Render check** — verified via GitHub's `/markdown` API (`gh api -X POST /markdown -f mode=gfm`): the 5-backtick outer fence renders as one combined `<div class="highlight"><pre>` containing all three inner snippets as literal text with markdown syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)