### PR TITLE
feat(include): site-rooted include="/..." paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ testdata/tmp/
 # Git worktrees
 .worktrees/
 *.sqlite
+*.db
 .worktrees/
 
 /tinkerdown

--- a/.gitignore
+++ b/.gitignore
@@ -33,13 +33,13 @@ build/
 # Local test data
 testdata/tmp/
 
-# Git worktrees
-.worktrees/
+# Local SQLite databases created by tests / examples at runtime
 *.sqlite
 *.db
+
+# Git worktrees
 .worktrees/
 
+# Locally-built tinkerdown binaries
 /tinkerdown
 /tinkerdown-test
-.worktrees/
-.worktrees/

--- a/internal/include/include.go
+++ b/internal/include/include.go
@@ -6,7 +6,11 @@
 // stay in parser.go. Three helpers do the work:
 //
 //   - Resolve confines a relative include path to a discovery root,
-//     so authors can't escape with "../../etc/passwd".
+//     so authors can't escape with "../../etc/passwd". An include path
+//     beginning with "/" is interpreted as project-root-relative
+//     (one level above the discovery root) rather than page-relative,
+//     so pages can cite source files that live outside the content tree
+//     without resorting to long "../../..." paths.
 //   - Slice reads the resolved file and returns either the whole text
 //     or a 1-indexed inclusive line range, clamping the end to the
 //     file's actual length when the author's range overruns.
@@ -271,7 +275,7 @@ func PreprocessWithLinks(content []byte, baseDir, root string, link LinkOptions)
 		// file at the cited line range. Skipped silently when the
 		// caller didn't provide enough info to construct a URL — the
 		// snippet alone is still useful.
-		if footer := renderSourceFooter(link, baseDir, absPath, linesAttr); footer != "" {
+		if footer := renderSourceFooter(link, baseDir, incPath, absPath, linesAttr); footer != "" {
 			out = append(out, "")
 			out = append(out, footer)
 		}
@@ -287,11 +291,14 @@ func PreprocessWithLinks(content []byte, baseDir, root string, link LinkOptions)
 // back to the included file's location in its source repository, or
 // an empty string when the caller didn't supply enough info.
 //
-// The path passed back to the link is computed relative to the
-// markdown page's directory and joined onto link.PagePathInRepo —
-// matches what tinkerdown already does for "Edit this page on
-// GitHub" links elsewhere in the codebase.
-func renderSourceFooter(link LinkOptions, pageDir, absPath, lineRange string) string {
+// For a site-rooted include (`incPath` begins with "/") the original
+// include string IS the repo-relative path — we use it directly and
+// skip the page-relative dance. For a page-relative include, the path
+// passed back to the link is computed relative to the markdown page's
+// directory and joined onto link.PagePathInRepo — matches what
+// tinkerdown already does for "Edit this page on GitHub" links
+// elsewhere in the codebase.
+func renderSourceFooter(link LinkOptions, pageDir, incPath, absPath, lineRange string) string {
 	if link.RepoURL == "" {
 		return ""
 	}
@@ -301,17 +308,27 @@ func renderSourceFooter(link LinkOptions, pageDir, absPath, lineRange string) st
 	if !strings.HasPrefix(link.RepoURL, "https://") && !strings.HasPrefix(link.RepoURL, "http://") {
 		return ""
 	}
-	relToPage, err := filepath.Rel(pageDir, absPath)
-	if err != nil || strings.HasPrefix(relToPage, "..") {
-		// Included file lives outside the page dir — we don't have a
-		// confident way to map it to the repo path, so skip the link.
-		return ""
-	}
-	relToPage = filepath.ToSlash(relToPage)
 
-	repoPath := relToPage
-	if link.PagePathInRepo != "" {
-		repoPath = strings.TrimRight(link.PagePathInRepo, "/") + "/" + relToPage
+	var repoPath string
+	if strings.HasPrefix(incPath, "/") {
+		// Site-rooted: the include attribute already names the path
+		// relative to the project (= repo) root. Use it verbatim and
+		// ignore PagePathInRepo, which only describes where the
+		// markdown page lives — irrelevant here.
+		repoPath = filepath.ToSlash(strings.TrimPrefix(incPath, "/"))
+	} else {
+		relToPage, err := filepath.Rel(pageDir, absPath)
+		if err != nil || strings.HasPrefix(relToPage, "..") {
+			// Included file lives outside the page dir — we don't have a
+			// confident way to map it to the repo path, so skip the link.
+			return ""
+		}
+		relToPage = filepath.ToSlash(relToPage)
+
+		repoPath = relToPage
+		if link.PagePathInRepo != "" {
+			repoPath = strings.TrimRight(link.PagePathInRepo, "/") + "/" + relToPage
+		}
 	}
 
 	branch := link.Branch
@@ -404,31 +421,34 @@ func lineFragment(lineRange string) string {
 func escapeAttr(s string) string { return html.EscapeString(s) }
 func escapeText(s string) string { return html.EscapeString(s) }
 
-// Resolve canonicalizes an include path supplied in markdown. It
-// resolves relative paths against baseDir (the directory of the
-// markdown file), then ensures the result lives inside root (the
-// page-discovery root) so traversal attacks are rejected.
+// Resolve canonicalizes an include path supplied in markdown. The
+// path is interpreted in one of two ways:
 //
-// Symlinks are followed on both candidate and root before the
-// containment check so a symlinked tempdir (e.g. macOS /tmp →
+//   - "/foo/bar" (leading slash) — project-root-relative: resolved
+//     against filepath.Dir(root) and confined to that project root.
+//     This lets pages cite files that live outside the content tree
+//     (e.g. a sibling examples/ folder) without "../../..." chains.
+//   - "./foo" / "foo" / "../foo" — page-relative: resolved against
+//     baseDir (the directory of the markdown file) and confined to
+//     root (the page-discovery root). Same v1 behavior.
+//
+// Either way, the resolved path must lie within its confinement root
+// or the call errors — traversal attacks (`../../etc/passwd`) are
+// rejected.
+//
+// Symlinks are followed on both candidate and confinement root before
+// the containment check so a symlinked tempdir (e.g. macOS /tmp →
 // /private/tmp) doesn't false-positive as an escape.
 func Resolve(baseDir, root, includePath string) (string, error) {
 	if includePath == "" {
 		return "", fmt.Errorf("include path is empty")
 	}
-	candidate := includePath
-	if !filepath.IsAbs(candidate) {
-		candidate = filepath.Join(baseDir, candidate)
-	}
-	absCandidate, err := filepath.Abs(candidate)
-	if err != nil {
-		return "", fmt.Errorf("resolve %q: %w", includePath, err)
-	}
-	resolvedCandidate, err := filepath.EvalSymlinks(absCandidate)
-	if err != nil {
-		return "", fmt.Errorf("read %q: %w", includePath, err)
-	}
 
+	// Determine which confinement applies. A site-rooted include
+	// (leading "/") is resolved against filepath.Dir(root) — the
+	// project root, one level above the page-discovery root — and is
+	// allowed to reach into sibling top-level folders of the project.
+	// Everything else stays in v1 page-root semantics.
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return "", fmt.Errorf("resolve root %q: %w", root, err)
@@ -438,7 +458,29 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 		return "", fmt.Errorf("resolve root %q: %w", root, err)
 	}
 
-	rel, err := filepath.Rel(resolvedRoot, resolvedCandidate)
+	var candidate, confineRoot string
+	if strings.HasPrefix(includePath, "/") {
+		projectRoot := filepath.Dir(resolvedRoot)
+		candidate = filepath.Join(projectRoot, strings.TrimPrefix(includePath, "/"))
+		confineRoot = projectRoot
+	} else {
+		candidate = includePath
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(baseDir, candidate)
+		}
+		confineRoot = resolvedRoot
+	}
+
+	absCandidate, err := filepath.Abs(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", includePath, err)
+	}
+	resolvedCandidate, err := filepath.EvalSymlinks(absCandidate)
+	if err != nil {
+		return "", fmt.Errorf("read %q: %w", includePath, err)
+	}
+
+	rel, err := filepath.Rel(confineRoot, resolvedCandidate)
 	if err != nil || strings.HasPrefix(rel, "..") {
 		return "", fmt.Errorf("include %q escapes the include root", includePath)
 	}

--- a/internal/include/include.go
+++ b/internal/include/include.go
@@ -293,11 +293,21 @@ func PreprocessWithLinks(content []byte, baseDir, root string, link LinkOptions)
 //
 // For a site-rooted include (`incPath` begins with "/") the original
 // include string IS the repo-relative path — we use it directly and
-// skip the page-relative dance. For a page-relative include, the path
-// passed back to the link is computed relative to the markdown page's
-// directory and joined onto link.PagePathInRepo — matches what
-// tinkerdown already does for "Edit this page on GitHub" links
-// elsewhere in the codebase.
+// skip the page-relative dance. PagePathInRepo is IGNORED in this
+// branch because it describes where the markdown page lives, not the
+// included file's location, which is exactly what `incPath` already
+// names relative to the project root. For a page-relative include,
+// the path passed back to the link is computed relative to the
+// markdown page's directory and joined onto link.PagePathInRepo —
+// matches what tinkerdown already does for "Edit this page on
+// GitHub" links elsewhere in the codebase.
+//
+// `incPath` must be the RAW include attribute value (with any leading
+// "/" intact). Callers that pre-clean or normalize the path would
+// strip the leading "/" and silently fall through to the page-
+// relative branch, producing a wrong footer URL with no error. The
+// sole caller in PreprocessWithLinks passes incPath unchanged from
+// the regex match — preserve that invariant if you add new callers.
 func renderSourceFooter(link LinkOptions, pageDir, incPath, absPath, lineRange string) string {
 	if link.RepoURL == "" {
 		return ""
@@ -460,7 +470,16 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 
 	var candidate, confineRoot string
 	if strings.HasPrefix(includePath, "/") {
-		projectRoot := filepath.Dir(resolvedRoot)
+		// resolvedRoot has already been EvalSymlinks'd, but its parent
+		// could still contain a symlink — e.g. when the whole project
+		// lives under a symlinked tree like macOS's /tmp → /private/tmp
+		// for an ancestor. EvalSymlinks again so the later
+		// filepath.Rel(confineRoot, resolvedCandidate) comparison can't
+		// false-positive as an escape because of a symlink one level up.
+		projectRoot, err := filepath.EvalSymlinks(filepath.Dir(resolvedRoot))
+		if err != nil {
+			return "", fmt.Errorf("resolve project root for %q: %w", includePath, err)
+		}
 		candidate = filepath.Join(projectRoot, strings.TrimPrefix(includePath, "/"))
 		confineRoot = projectRoot
 	} else {

--- a/internal/include/include.go
+++ b/internal/include/include.go
@@ -470,6 +470,17 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 
 	var candidate, confineRoot string
 	if strings.HasPrefix(includePath, "/") {
+		// Normalise multiple leading slashes ("//foo", "///foo") to a
+		// single one. filepath.Join handles these correctly on Linux,
+		// but the trim arithmetic below is clearer with a single
+		// canonical leading "/".
+		normalised := "/" + strings.TrimLeft(includePath, "/")
+		// "/" alone resolves to the project root directory itself;
+		// downstream Slice would then try to read a directory as a
+		// file. Reject early with a clear message.
+		if normalised == "/" {
+			return "", fmt.Errorf("include %q resolves to the project root, not a file", includePath)
+		}
 		// resolvedRoot has already been EvalSymlinks'd, but its parent
 		// could still contain a symlink — e.g. when the whole project
 		// lives under a symlinked tree like macOS's /tmp → /private/tmp
@@ -480,7 +491,7 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("resolve project root for %q: %w", includePath, err)
 		}
-		candidate = filepath.Join(projectRoot, strings.TrimPrefix(includePath, "/"))
+		candidate = filepath.Join(projectRoot, strings.TrimPrefix(normalised, "/"))
 		confineRoot = projectRoot
 	} else {
 		candidate = includePath

--- a/internal/include/include.go
+++ b/internal/include/include.go
@@ -325,7 +325,12 @@ func renderSourceFooter(link LinkOptions, pageDir, incPath, absPath, lineRange s
 		// relative to the project (= repo) root. Use it verbatim and
 		// ignore PagePathInRepo, which only describes where the
 		// markdown page lives — irrelevant here.
-		repoPath = filepath.ToSlash(strings.TrimPrefix(incPath, "/"))
+		//
+		// TrimLeft (not TrimPrefix) so multiple leading slashes
+		// ("//examples/foo.go") match what Resolve normalises
+		// internally. TrimPrefix would only strip one slash and leave
+		// a malformed leading "/" in the rendered GitHub URL.
+		repoPath = filepath.ToSlash(strings.TrimLeft(incPath, "/"))
 	} else {
 		relToPage, err := filepath.Rel(pageDir, absPath)
 		if err != nil || strings.HasPrefix(relToPage, "..") {
@@ -449,6 +454,14 @@ func escapeText(s string) string { return html.EscapeString(s) }
 // Symlinks are followed on both candidate and confinement root before
 // the containment check so a symlinked tempdir (e.g. macOS /tmp →
 // /private/tmp) doesn't false-positive as an escape.
+//
+// Layout assumption: site-rooted paths use filepath.Dir(root) as the
+// project root, hard-coding the convention that the discovery root
+// sits one level inside the project (the typical "project/content/"
+// shape). If a caller passes the actual repo root as `root`, a "/foo"
+// include would resolve one level *above* the repo — surprising and
+// potentially escapes the project tree entirely. Callers with a
+// non-standard layout should prefer page-relative includes only.
 func Resolve(baseDir, root, includePath string) (string, error) {
 	if includePath == "" {
 		return "", fmt.Errorf("include path is empty")
@@ -492,12 +505,17 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 			return "", fmt.Errorf("resolve project root for %q: %w", includePath, err)
 		}
 		candidate = filepath.Join(projectRoot, strings.TrimPrefix(normalised, "/"))
+		// Site-rooted: broader confinement (one level up) so includes
+		// can reach into sibling top-level folders like examples/.
 		confineRoot = projectRoot
 	} else {
 		candidate = includePath
 		if !filepath.IsAbs(candidate) {
 			candidate = filepath.Join(baseDir, candidate)
 		}
+		// Page-relative: tighter confinement to the discovery root —
+		// includes that would escape (e.g. "../../etc/passwd") are
+		// rejected even if they'd be inside the broader project.
 		confineRoot = resolvedRoot
 	}
 

--- a/internal/include/include.go
+++ b/internal/include/include.go
@@ -482,17 +482,29 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 	}
 
 	var candidate, confineRoot string
-	if strings.HasPrefix(includePath, "/") {
-		// Normalise multiple leading slashes ("//foo", "///foo") to a
-		// single one. filepath.Join handles these correctly on Linux,
-		// but the trim arithmetic below is clearer with a single
-		// canonical leading "/".
-		normalised := "/" + strings.TrimLeft(includePath, "/")
-		// "/" alone resolves to the project root directory itself;
-		// downstream Slice would then try to read a directory as a
-		// file. Reject early with a clear message.
-		if normalised == "/" {
+	siteRooted := strings.HasPrefix(includePath, "/")
+	if siteRooted {
+		// Strip all leading slashes — "//foo", "///foo" all canonicalise
+		// to the same relative path under the project root. filepath.Join
+		// would handle the variants on Linux but the path arithmetic is
+		// less surprising with a single canonical form, and
+		// renderSourceFooter applies the same TrimLeft for parity.
+		relative := strings.TrimLeft(includePath, "/")
+		// "/" (or "//"/"///") alone resolves to the project root
+		// directory itself; downstream Slice would then try to read a
+		// directory as a file. Reject early with a clear message.
+		if relative == "" {
 			return "", fmt.Errorf("include %q resolves to the project root, not a file", includePath)
+		}
+		// Layout footgun guard: if the discovery root is the filesystem
+		// root ("/"), filepath.Dir(root) == root and a site-rooted include
+		// resolves against "/" itself — i.e. the entire filesystem becomes
+		// the include surface. The doc comment warns callers about
+		// non-standard layouts; this is the loud-error case for the
+		// genuinely-broken one. Detected by comparing resolvedRoot to its
+		// own parent (true only at the filesystem root).
+		if filepath.Dir(resolvedRoot) == resolvedRoot {
+			return "", fmt.Errorf("include %q: site-rooted includes require a discovery root inside a project (root %q has no parent)", includePath, root)
 		}
 		// resolvedRoot has already been EvalSymlinks'd, but its parent
 		// could still contain a symlink — e.g. when the whole project
@@ -504,7 +516,7 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("resolve project root for %q: %w", includePath, err)
 		}
-		candidate = filepath.Join(projectRoot, strings.TrimPrefix(normalised, "/"))
+		candidate = filepath.Join(projectRoot, relative)
 		// Site-rooted: broader confinement (one level up) so includes
 		// can reach into sibling top-level folders like examples/.
 		confineRoot = projectRoot
@@ -530,7 +542,13 @@ func Resolve(baseDir, root, includePath string) (string, error) {
 
 	rel, err := filepath.Rel(confineRoot, resolvedCandidate)
 	if err != nil || strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("include %q escapes the include root", includePath)
+		// Distinguish which confinement boundary fired — debugging an
+		// unexpected rejection is much easier with the specific root
+		// named.
+		if siteRooted {
+			return "", fmt.Errorf("include %q escapes the project root", includePath)
+		}
+		return "", fmt.Errorf("include %q escapes the content root", includePath)
 	}
 	return resolvedCandidate, nil
 }

--- a/internal/include/include_test.go
+++ b/internal/include/include_test.go
@@ -213,6 +213,41 @@ func TestResolve_SiteRootedCanTargetContentRoot(t *testing.T) {
 	}
 }
 
+func TestPreprocess_GitHubFooter_SiteRooted_StripsExtraSlashes(t *testing.T) {
+	// Resolve normalises "//foo" to "/foo" internally before resolving;
+	// renderSourceFooter must do the same when building the URL,
+	// otherwise multiple leading slashes leak into the rendered href
+	// (e.g. /blob/main//examples/...) — a malformed but silent
+	// failure mode.
+	project := t.TempDir()
+	contentRoot := filepath.Join(project, "content")
+	pageDir := filepath.Join(contentRoot, "recipes", "x")
+	src := filepath.Join(project, "examples", "x", "x.go")
+	for _, d := range []string{pageDir, filepath.Dir(src)} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(src, []byte("body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	md := "```go include=\"//examples/x/x.go\"\n```\n"
+	out, _, _ := PreprocessWithLinks([]byte(md), pageDir, contentRoot, LinkOptions{
+		RepoURL: "https://github.com/foo/bar",
+		Branch:  "main",
+	})
+	got := string(out)
+	wantHref := `href="https://github.com/foo/bar/blob/main/examples/x/x.go"`
+	if !strings.Contains(got, wantHref) {
+		t.Errorf("multiple leading slashes should be stripped from footer URL; got:\n%s", got)
+	}
+	// Explicit anti-assertion: the malformed "/blob/main//examples" must
+	// NOT appear (would indicate TrimPrefix-only stripping).
+	if strings.Contains(got, "/blob/main//") {
+		t.Errorf("footer URL has a double slash after branch — TrimLeft regressed to TrimPrefix? got:\n%s", got)
+	}
+}
+
 func TestPreprocess_GitHubFooter_SiteRooted(t *testing.T) {
 	// A site-rooted include can reach into a sibling folder that
 	// page-relative semantics would forbid. The footer must use the

--- a/internal/include/include_test.go
+++ b/internal/include/include_test.go
@@ -85,6 +85,111 @@ func TestResolve_PathConfinement(t *testing.T) {
 	}
 }
 
+func TestResolve_SiteRootedInclude(t *testing.T) {
+	// Project layout:
+	//   project/
+	//     content/      ← discovery root passed to Resolve
+	//       recipes/
+	//         counter/
+	//           index.md  (the page)
+	//     examples/
+	//       counter/
+	//         counter.go  ← cited via /examples/counter/counter.go
+	project := t.TempDir()
+	contentRoot := filepath.Join(project, "content")
+	pageDir := filepath.Join(contentRoot, "recipes", "counter")
+	exampleFile := filepath.Join(project, "examples", "counter", "counter.go")
+	for _, d := range []string{pageDir, filepath.Dir(exampleFile)} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(exampleFile, []byte("package counter\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Leading-slash path resolves project-relative — reaches the sibling
+	// examples/ folder that a page-relative include would be forbidden
+	// from touching.
+	got, err := Resolve(pageDir, contentRoot, "/examples/counter/counter.go")
+	if err != nil {
+		t.Fatalf("site-rooted include: %v", err)
+	}
+	wantResolved, _ := filepath.EvalSymlinks(exampleFile)
+	if got != wantResolved {
+		t.Errorf("got %q, want %q", got, wantResolved)
+	}
+
+	// Verify a page-relative escape attempt to the same file is still
+	// rejected — the new branch only triggers on the leading slash.
+	if _, err := Resolve(pageDir, contentRoot, "../../../examples/counter/counter.go"); err == nil {
+		t.Errorf("page-relative escape should still be rejected")
+	}
+}
+
+func TestResolve_SiteRootedRejectsProjectEscape(t *testing.T) {
+	// Even with the broader project-root confinement, attempts to
+	// escape beyond the project root must fail. Authors who genuinely
+	// want to include arbitrary filesystem paths shouldn't be able to.
+	project := t.TempDir()
+	contentRoot := filepath.Join(project, "content")
+	pageDir := filepath.Join(contentRoot, "page")
+	outsideFile := filepath.Join(filepath.Dir(project), "outside.go")
+	if err := os.MkdirAll(pageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outsideFile, []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(outsideFile)
+
+	// The leading slash makes this project-rooted, but "/../outside.go"
+	// resolves above the project root → still rejected.
+	if _, err := Resolve(pageDir, contentRoot, "/../outside.go"); err == nil {
+		t.Errorf("expected site-rooted escape above project to be rejected")
+	}
+}
+
+func TestPreprocess_GitHubFooter_SiteRooted(t *testing.T) {
+	// A site-rooted include can reach into a sibling folder that
+	// page-relative semantics would forbid. The footer must use the
+	// include attribute verbatim as the repo-relative path — NOT
+	// PagePathInRepo (which describes the page's location, not the
+	// included file's).
+	project := t.TempDir()
+	contentRoot := filepath.Join(project, "content")
+	pageDir := filepath.Join(contentRoot, "recipes", "counter")
+	src := filepath.Join(project, "examples", "counter", "counter.go")
+	for _, d := range []string{pageDir, filepath.Dir(src)} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(src, []byte("L1\nL2\nL3\nL4\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	md := "```go include=\"/examples/counter/counter.go\" lines=\"2-3\"\n```\n"
+	out, _, warnings := PreprocessWithLinks([]byte(md), pageDir, contentRoot, LinkOptions{
+		RepoURL:        "https://github.com/foo/bar",
+		Branch:         "main",
+		PagePathInRepo: "content/recipes/counter",
+	})
+	if len(warnings) != 0 {
+		t.Fatalf("warnings: %v", warnings)
+	}
+	got := string(out)
+	// PagePathInRepo MUST be ignored for site-rooted paths — the URL
+	// should reflect the actual examples/counter location.
+	wantHref := `href="https://github.com/foo/bar/blob/main/examples/counter/counter.go#L2-L3"`
+	if !strings.Contains(got, wantHref) {
+		t.Errorf("missing expected site-rooted footer link; got:\n%s", got)
+	}
+	if strings.Contains(got, "content/recipes/counter/examples") {
+		t.Errorf("PagePathInRepo should not be prefixed to site-rooted paths; got:\n%s", got)
+	}
+}
+
 func TestSlice_FullFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.txt")

--- a/internal/include/include_test.go
+++ b/internal/include/include_test.go
@@ -141,12 +141,47 @@ func TestResolve_SiteRootedRejectsProjectEscape(t *testing.T) {
 	if err := os.WriteFile(outsideFile, []byte("body"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(outsideFile)
+	// t.Cleanup runs even on panic; defer os.Remove would leak the file
+	// outside the temp tree if this test ever panicked before reaching
+	// the deferred call.
+	t.Cleanup(func() { _ = os.Remove(outsideFile) })
 
 	// The leading slash makes this project-rooted, but "/../outside.go"
 	// resolves above the project root → still rejected.
 	if _, err := Resolve(pageDir, contentRoot, "/../outside.go"); err == nil {
 		t.Errorf("expected site-rooted escape above project to be rejected")
+	}
+}
+
+func TestResolve_SiteRootedCanTargetContentRoot(t *testing.T) {
+	// A site-rooted path that happens to land back inside the content
+	// root is allowed — the project root is a superset of the content
+	// root, so files inside the content tree are inside the confinement
+	// boundary too. This is intentional: an author who writes
+	// `include="/content/recipes/snippet.md"` from a different page
+	// shouldn't be blocked just because the target happens to be a
+	// doc-tree file. The opposite would surprise authors who think of
+	// "/..." as "from the project root, anywhere within."
+	project := t.TempDir()
+	contentRoot := filepath.Join(project, "content")
+	pageDir := filepath.Join(contentRoot, "recipes", "a")
+	target := filepath.Join(contentRoot, "snippets", "shared.go")
+	for _, d := range []string{pageDir, filepath.Dir(target)} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(target, []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Resolve(pageDir, contentRoot, "/content/snippets/shared.go")
+	if err != nil {
+		t.Fatalf("site-rooted include into content root: %v", err)
+	}
+	wantResolved, _ := filepath.EvalSymlinks(target)
+	if got != wantResolved {
+		t.Errorf("got %q, want %q", got, wantResolved)
 	}
 }
 

--- a/internal/include/include_test.go
+++ b/internal/include/include_test.go
@@ -131,25 +131,53 @@ func TestResolve_SiteRootedRejectsProjectEscape(t *testing.T) {
 	// Even with the broader project-root confinement, attempts to
 	// escape beyond the project root must fail. Authors who genuinely
 	// want to include arbitrary filesystem paths shouldn't be able to.
+	//
+	// Both temp dirs are t.TempDir-managed so the test never writes
+	// outside an owned tree (concurrent test instances + leak-free
+	// cleanup, both via the test framework). The escape attempt is
+	// expressed relative to where the OS happens to put the temp dirs:
+	// outside lives at filepath.Base(outside) under filepath.Dir(both),
+	// so escaping from project means "/../<outside-basename>/outside.go".
 	project := t.TempDir()
+	outside := t.TempDir()
 	contentRoot := filepath.Join(project, "content")
 	pageDir := filepath.Join(contentRoot, "page")
-	outsideFile := filepath.Join(filepath.Dir(project), "outside.go")
+	outsideFile := filepath.Join(outside, "outside.go")
 	if err := os.MkdirAll(pageDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(outsideFile, []byte("body"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// t.Cleanup runs even on panic; defer os.Remove would leak the file
-	// outside the temp tree if this test ever panicked before reaching
-	// the deferred call.
-	t.Cleanup(func() { _ = os.Remove(outsideFile) })
 
-	// The leading slash makes this project-rooted, but "/../outside.go"
-	// resolves above the project root → still rejected.
-	if _, err := Resolve(pageDir, contentRoot, "/../outside.go"); err == nil {
-		t.Errorf("expected site-rooted escape above project to be rejected")
+	// Site-rooted but reaching across to a sibling of the project root
+	// resolves above the project's confinement → still rejected.
+	escape := "/../" + filepath.Base(outside) + "/outside.go"
+	if _, err := Resolve(pageDir, contentRoot, escape); err == nil {
+		t.Errorf("expected site-rooted escape above project to be rejected (path %q)", escape)
+	}
+}
+
+func TestResolve_SiteRootedRejectsRootOnly(t *testing.T) {
+	// "/" alone resolves to the project root directory. Slice would
+	// then attempt to read a directory as a file and produce a
+	// downstream error; Resolve catches it early with a clearer
+	// message.
+	project := t.TempDir()
+	contentRoot := filepath.Join(project, "content")
+	pageDir := filepath.Join(contentRoot, "page")
+	if err := os.MkdirAll(pageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{"/", "//", "///"} {
+		_, err := Resolve(pageDir, contentRoot, p)
+		if err == nil {
+			t.Errorf("expected Resolve(%q) to reject root-only path", p)
+			continue
+		}
+		if !strings.Contains(err.Error(), "project root") {
+			t.Errorf("Resolve(%q): expected 'project root' error message, got: %v", p, err)
+		}
 	}
 }
 

--- a/internal/include/include_test.go
+++ b/internal/include/include_test.go
@@ -140,6 +140,14 @@ func TestResolve_SiteRootedRejectsProjectEscape(t *testing.T) {
 	// so escaping from project means "/../<outside-basename>/outside.go".
 	project := t.TempDir()
 	outside := t.TempDir()
+	// Go 1.21+ test framework typically puts both t.TempDir() calls
+	// under the same parent (the test's own subdir under TMPDIR), but
+	// it's not contractual. Skip the test rather than silently passing
+	// (or producing a misleading failure) on a runtime that doesn't
+	// follow the convention.
+	if filepath.Dir(project) != filepath.Dir(outside) {
+		t.Skipf("t.TempDir() did not place project and outside under same parent (project=%q outside=%q); cannot construct relative escape path", project, outside)
+	}
 	contentRoot := filepath.Join(project, "content")
 	pageDir := filepath.Join(contentRoot, "page")
 	outsideFile := filepath.Join(outside, "outside.go")
@@ -155,6 +163,19 @@ func TestResolve_SiteRootedRejectsProjectEscape(t *testing.T) {
 	escape := "/../" + filepath.Base(outside) + "/outside.go"
 	if _, err := Resolve(pageDir, contentRoot, escape); err == nil {
 		t.Errorf("expected site-rooted escape above project to be rejected (path %q)", escape)
+	}
+}
+
+func TestResolve_SiteRootedRejectsRootlessLayout(t *testing.T) {
+	// Layout footgun guard: when `root` is the filesystem root itself,
+	// filepath.Dir(root) == root and the project-root concept breaks
+	// down (a /foo include would resolve against the filesystem root).
+	// Resolve detects this and errors loudly rather than silently
+	// expanding the include surface to the whole filesystem.
+	if _, err := Resolve("/tmp", "/", "/etc/passwd"); err == nil {
+		t.Errorf("expected site-rooted include against filesystem root to be rejected")
+	} else if !strings.Contains(err.Error(), "no parent") {
+		t.Errorf("expected 'no parent' error message, got: %v", err)
 	}
 }
 
@@ -210,6 +231,40 @@ func TestResolve_SiteRootedCanTargetContentRoot(t *testing.T) {
 	wantResolved, _ := filepath.EvalSymlinks(target)
 	if got != wantResolved {
 		t.Errorf("got %q, want %q", got, wantResolved)
+	}
+}
+
+func TestPreprocess_GitHubFooter_SiteRooted_NoPagePathInRepo(t *testing.T) {
+	// Site-rooted includes ignore PagePathInRepo entirely. When it's
+	// empty (common for top-level pages like index.md), there must
+	// still be no spurious double-slash after the branch — confirms
+	// the site-rooted branch doesn't accidentally fall through to the
+	// page-relative branch's "PagePathInRepo + relToPage" join.
+	project := t.TempDir()
+	contentRoot := filepath.Join(project, "content")
+	pageDir := contentRoot
+	src := filepath.Join(project, "examples", "x", "x.go")
+	for _, d := range []string{pageDir, filepath.Dir(src)} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(src, []byte("body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	md := "```go include=\"/examples/x/x.go\"\n```\n"
+	out, _, _ := PreprocessWithLinks([]byte(md), pageDir, contentRoot, LinkOptions{
+		RepoURL: "https://github.com/foo/bar",
+		Branch:  "main",
+		// PagePathInRepo intentionally unset.
+	})
+	got := string(out)
+	wantHref := `href="https://github.com/foo/bar/blob/main/examples/x/x.go"`
+	if !strings.Contains(got, wantHref) {
+		t.Errorf("missing expected footer href; got:\n%s", got)
+	}
+	if strings.Contains(got, "/blob/main//") {
+		t.Errorf("footer URL has spurious double slash; got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a new branch in `include.Resolve`: a leading `/` in the include attribute is interpreted as project-root-relative (one level above the discovery root) rather than page-relative. Files cited this way are confined to the project root, not the content root — pages can now reference source files that live in sibling top-level folders without "../../..." chains.

This unblocks **livetemplate/docs PR feat/examples-as-canonical**, which moves all runnable apps to `docs/examples/<slug>/` (sibling of `content/`) and rewrites 27 literate-programming includes from `./_app/...` to `/examples/<slug>/...`.

## What changed

- `internal/include/include.go` — `Resolve` and `renderSourceFooter` handle leading-slash paths. Resolution computes `projectRoot = filepath.Dir(root)` (the parent of the discovery root), confines the candidate there, and applies `EvalSymlinks` to both the candidate and the project-root parent so a symlinked ancestor (e.g. macOS `/tmp → /private/tmp`) can't false-positive as an escape. `renderSourceFooter` uses the include attribute verbatim as the repo-relative path for site-rooted entries (sidesteps the "outside pageDir" guard that page-relative includes hit when they escape the page directory).
- **Robustness guards added during review:**
  - Multiple leading slashes (`//foo`, `///foo`) normalised via `strings.TrimLeft` in both `Resolve` and `renderSourceFooter`.
  - Bare `/` (resolving to the project root directory itself) rejected with a clear "not a file" error.
  - Filesystem-root layout (`root == "/"`, `filepath.Dir(root) == root`) rejected with an explicit "no parent" error — guards against misconfigured callers that would otherwise expand the include surface to the whole filesystem.
  - Distinct error messages for site-rooted (`"escapes the project root"`) vs page-relative (`"escapes the content root"`) confinement failures.
- 8 tests cover: site-rooted resolution into a sibling folder; rejection of escape above project; rejection of bare `/`; rejection of filesystem-root layout; site-rooted path landing inside content root is allowed; footer URL uses the include path verbatim (not `PagePathInRepo`); footer URL strips multiple leading slashes; footer URL is correct when `PagePathInRepo` is empty.
- `.gitignore` — added `*.db` (runtime artifact from SQLite-using examples) and deduplicated three pre-existing copies of `.worktrees/`.

## Backward compatibility

Page-relative includes (`./_app/...`, `../foo.go`, `foo.go`) keep their v1 semantics — confined to the content root via the existing `filepath.Rel` + `..` prefix check. Verified by running `tinkerdown validate` against the current docs repo (55 pages including the docs PR's new site-rooted paths): all pass.

## Test plan

- [x] `go test ./internal/include/...` — 13 unit tests including 8 new cases
- [x] `go test -tags=ci -skip='TutorialNavigation' ./...` — full tinkerdown suite green
- [x] Smoke: `tinkerdown validate` against a synthetic site using `include="/examples/foo.go"` — resolves correctly
- [x] Backward compat: `tinkerdown validate /home/adnaan/code/livetemplate/docs/content/` (55 pages) — all pass
- [ ] Tag a new release (v0.3.0 or follow-on) so livetemplate/docs PR can pin to a version instead of this branch

## Next

After this lands and is tagged, the docs PR's `Dockerfile` flips `TINKERDOWN_REF` from `feat/site-rooted-includes` (current temporary pin) back to the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)