### PR TITLE
fix(server): serve web fonts when the host has no mime database

### DIFF
--- a/internal/server/landing_layout_test.go
+++ b/internal/server/landing_layout_test.go
@@ -200,3 +200,40 @@ func TestServeUserAsset(t *testing.T) {
 		}
 	})
 }
+
+// TestAssetContentType guards the host-independent MIME resolution. The
+// fallback table is asserted directly so the test cannot false-pass on a host
+// whose mime database already knows web fonts (e.g. a dev machine with
+// /etc/mime.types) — that very host-dependence is what 404s fonts on a minimal
+// alpine deploy.
+func TestAssetContentType(t *testing.T) {
+	t.Run("fallback table covers web fonts", func(t *testing.T) {
+		want := map[string]string{
+			".woff2": "font/woff2",
+			".woff":  "font/woff",
+			".ttf":   "font/ttf",
+			".otf":   "font/otf",
+			".eot":   "application/vnd.ms-fontobject",
+		}
+		for ext, ct := range want {
+			if got := fallbackAssetTypes[ext]; got != ct {
+				t.Errorf("fallbackAssetTypes[%q] = %q, want %q", ext, got, ct)
+			}
+		}
+	})
+
+	t.Run("resolves fonts and rejects unknown", func(t *testing.T) {
+		if got := assetContentType(".woff2"); got != "font/woff2" {
+			t.Errorf("assetContentType(.woff2) = %q, want font/woff2", got)
+		}
+		// Case-insensitive, mirroring mime.TypeByExtension.
+		if got := assetContentType(".WOFF2"); got != "font/woff2" {
+			t.Errorf("assetContentType(.WOFF2) = %q, want font/woff2", got)
+		}
+		// Genuinely unknown extensions stay empty so serveUserAsset still refuses
+		// them (nosniff defense against MIME confusion).
+		if got := assetContentType(".totallybogus"); got != "" {
+			t.Errorf("assetContentType(.totallybogus) = %q, want \"\"", got)
+		}
+	})
+}

--- a/internal/server/landing_layout_test.go
+++ b/internal/server/landing_layout_test.go
@@ -223,6 +223,11 @@ func TestAssetContentType(t *testing.T) {
 	})
 
 	t.Run("resolves fonts and rejects unknown", func(t *testing.T) {
+		// Host DB wins over the fallback: .css is in Go's built-in table on
+		// every platform, so it resolves even where /etc/mime.types is absent.
+		if got := assetContentType(".css"); got == "" {
+			t.Errorf("assetContentType(.css) = empty, want a content type")
+		}
 		if got := assetContentType(".woff2"); got != "font/woff2" {
 			t.Errorf("assetContentType(.woff2) = %q, want font/woff2", got)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -778,6 +778,32 @@ func (s *Server) serveAsset(w http.ResponseWriter, r *http.Request) {
 	http.NotFound(w, r)
 }
 
+// fallbackAssetTypes maps well-known web-asset extensions to their MIME types
+// so serveUserAsset can resolve them without depending on the host OS mime
+// database. mime.TypeByExtension augments Go's small built-in table from OS
+// files (/etc/mime.types et al.), and minimal runtime images — notably the
+// alpine base this ships in — carry none of them. Go's built-in table knows
+// .css/.js/.svg but not web fonts, so without this table a deployed site 404s
+// every .woff2 while serving .css fine. Extensions are matched lowercased.
+var fallbackAssetTypes = map[string]string{
+	".woff2": "font/woff2",
+	".woff":  "font/woff",
+	".ttf":   "font/ttf",
+	".otf":   "font/otf",
+	".eot":   "application/vnd.ms-fontobject",
+}
+
+// assetContentType resolves the Content-Type for a user asset by extension. It
+// prefers the host mime database (via mime.TypeByExtension) and falls back to
+// fallbackAssetTypes for web fonts the host may not know. It returns "" only
+// for genuinely unknown extensions, preserving serveUserAsset's nosniff refusal.
+func assetContentType(ext string) string {
+	if ct := mime.TypeByExtension(ext); ct != "" {
+		return ct
+	}
+	return fallbackAssetTypes[strings.ToLower(ext)]
+}
+
 // serveUserAsset serves a file from <rootDir>/assets by its request-relative
 // path (already stripped of the "/assets/" prefix). Returns true if it wrote
 // a response. Guards against path traversal, refuses directories and unknown
@@ -800,7 +826,7 @@ func (s *Server) serveUserAsset(w http.ResponseWriter, r *http.Request, relPath 
 	if err != nil || info.IsDir() {
 		return false
 	}
-	ct := mime.TypeByExtension(filepath.Ext(full))
+	ct := assetContentType(filepath.Ext(full))
 	if ct == "" {
 		return false // refuse to serve unknown/sniffable types
 	}


### PR DESCRIPTION
## Problem

`serveUserAsset` refuses any file whose MIME type the host OS can't name (`mime.TypeByExtension(ext) == ""`). Go augments its small built-in type table from OS files (`/etc/mime.types` et al.); the **alpine** base tinkerdown ships in carries none of them, and Go's built-in table omits web fonts.

Result on a deployed site: **every `.woff2`/`.woff`/`.ttf` 404s while `.css` serves fine** — even though the font files are present on disk. (`.css` is in Go's built-in table; web fonts aren't.) Locally it works because dev machines have a mime database that knows fonts, which masks the bug.

Real-world hit: livetemplate.fly.dev landing page — all 8 Inter/JetBrains-Mono woff2 files 404, CSS loads.

## Fix

New `assetContentType` helper resolves the content type through the host mime database first, then falls back to a fixed table of well-known web-font extensions (`woff2`, `woff`, `ttf`, `otf`, `eot`) when the host comes up empty. The `nosniff` refusal for genuinely unknown types is preserved.

## Verification

Before/after in a bare `alpine:3.21` container (no `/etc/mime.types`, exactly like the prod runtime image):

| binary | `GET /assets/test.woff2` |
|---|---|
| unpatched (v0.3.5) | `404 Not Found` |
| patched | `200 OK` · `Content-Type: font/woff2` · `X-Content-Type-Options: nosniff` |

- New `TestAssetContentType` asserts the fallback table directly (host-independent — can't false-pass on a dev box whose mime DB already knows fonts).
- `go test -tags ci ./...` passes.
- Existing `TestServeUserAsset` still passes (css serving, nosniff, traversal guard, directory refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)