### PR TITLE
Nested, collapsible sidebar navigation (NavPage groups + native <details>)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,22 +14,22 @@ import (
 
 // Config represents the tinkerdown configuration
 type Config struct {
-	Title       string                   `yaml:"title"`
-	Description string                   `yaml:"description"`
-	Type        string                   `yaml:"type"` // "tutorial" or "site"
-	Site        *SiteConfig              `yaml:"site,omitempty"`
-	Navigation  []NavSection             `yaml:"navigation,omitempty"`
-	Server      ServerConfig             `yaml:"server"`
-	Styling     StylingConfig            `yaml:"styling"`
-	Blocks      BlocksConfig             `yaml:"blocks"`
-	Features    FeaturesConfig           `yaml:"features"`
-	Ignore      []string                 `yaml:"ignore"`
-	Sources     map[string]SourceConfig  `yaml:"sources,omitempty"`
-	Actions     map[string]*Action       `yaml:"actions,omitempty"`
-	API         *APIConfig               `yaml:"api,omitempty"`
-	Webhooks    map[string]*Webhook      `yaml:"webhooks,omitempty"`
+	Title       string                  `yaml:"title"`
+	Description string                  `yaml:"description"`
+	Type        string                  `yaml:"type"` // "tutorial" or "site"
+	Site        *SiteConfig             `yaml:"site,omitempty"`
+	Navigation  []NavSection            `yaml:"navigation,omitempty"`
+	Server      ServerConfig            `yaml:"server"`
+	Styling     StylingConfig           `yaml:"styling"`
+	Blocks      BlocksConfig            `yaml:"blocks"`
+	Features    FeaturesConfig          `yaml:"features"`
+	Ignore      []string                `yaml:"ignore"`
+	Sources     map[string]SourceConfig `yaml:"sources,omitempty"`
+	Actions     map[string]*Action      `yaml:"actions,omitempty"`
+	API         *APIConfig              `yaml:"api,omitempty"`
+	Webhooks    map[string]*Webhook     `yaml:"webhooks,omitempty"`
 	Outputs     map[string]*OutputConfig `yaml:"outputs,omitempty"`
-	Security    SecurityConfig           `yaml:"security,omitempty"`
+	Security    SecurityConfig          `yaml:"security,omitempty"`
 
 	// VersionPrefix, when non-empty, becomes a URL path segment that is
 	// stripped from incoming requests before route resolution. Routes serve
@@ -168,9 +168,9 @@ type SourceConfig struct {
 	AutoBind    *bool                  `yaml:"auto_bind,omitempty"`    // Set to false to exclude from auto-table matching
 
 	// For computed sources: derive data from another source
-	GroupBy   string            `yaml:"group_by,omitempty"`  // Field to group by (e.g., "category")
-	Aggregate map[string]string `yaml:"aggregate,omitempty"` // Field → aggregation expression (e.g., "total": "sum(amount)")
-	Filter    string            `yaml:"filter,omitempty"`    // Optional filter expression (e.g., "status = active")
+	GroupBy   string            `yaml:"group_by,omitempty"`   // Field to group by (e.g., "category")
+	Aggregate map[string]string `yaml:"aggregate,omitempty"`  // Field → aggregation expression (e.g., "total": "sum(amount)")
+	Filter    string            `yaml:"filter,omitempty"`     // Optional filter expression (e.g., "status = active")
 }
 
 // RetryConfig configures retry behavior for a source
@@ -453,10 +453,10 @@ type SiteConfig struct {
 
 // NavSection represents a navigation section with pages
 type NavSection struct {
-	Title     string    `yaml:"title"`           // Section title (e.g., "Getting Started")
-	Path      string    `yaml:"path"`            // Section path (e.g., "getting-started")
-	Collapsed bool      `yaml:"collapsed"`       // Whether section is collapsed by default
-	Pages     []NavPage `yaml:"pages,omitempty"` // Pages in this section
+	Title     string    `yaml:"title"`              // Section title (e.g., "Getting Started")
+	Path      string    `yaml:"path"`               // Section path (e.g., "getting-started")
+	Collapsed bool      `yaml:"collapsed"`          // Whether section is collapsed by default
+	Pages     []NavPage `yaml:"pages,omitempty"`    // Pages in this section
 }
 
 // NavPage represents a single entry in navigation. It is either a leaf

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,22 +14,22 @@ import (
 
 // Config represents the tinkerdown configuration
 type Config struct {
-	Title       string                  `yaml:"title"`
-	Description string                  `yaml:"description"`
-	Type        string                  `yaml:"type"` // "tutorial" or "site"
-	Site        *SiteConfig             `yaml:"site,omitempty"`
-	Navigation  []NavSection            `yaml:"navigation,omitempty"`
-	Server      ServerConfig            `yaml:"server"`
-	Styling     StylingConfig           `yaml:"styling"`
-	Blocks      BlocksConfig            `yaml:"blocks"`
-	Features    FeaturesConfig          `yaml:"features"`
-	Ignore      []string                `yaml:"ignore"`
-	Sources     map[string]SourceConfig `yaml:"sources,omitempty"`
-	Actions     map[string]*Action      `yaml:"actions,omitempty"`
-	API         *APIConfig              `yaml:"api,omitempty"`
-	Webhooks    map[string]*Webhook     `yaml:"webhooks,omitempty"`
+	Title       string                   `yaml:"title"`
+	Description string                   `yaml:"description"`
+	Type        string                   `yaml:"type"` // "tutorial" or "site"
+	Site        *SiteConfig              `yaml:"site,omitempty"`
+	Navigation  []NavSection             `yaml:"navigation,omitempty"`
+	Server      ServerConfig             `yaml:"server"`
+	Styling     StylingConfig            `yaml:"styling"`
+	Blocks      BlocksConfig             `yaml:"blocks"`
+	Features    FeaturesConfig           `yaml:"features"`
+	Ignore      []string                 `yaml:"ignore"`
+	Sources     map[string]SourceConfig  `yaml:"sources,omitempty"`
+	Actions     map[string]*Action       `yaml:"actions,omitempty"`
+	API         *APIConfig               `yaml:"api,omitempty"`
+	Webhooks    map[string]*Webhook      `yaml:"webhooks,omitempty"`
 	Outputs     map[string]*OutputConfig `yaml:"outputs,omitempty"`
-	Security    SecurityConfig          `yaml:"security,omitempty"`
+	Security    SecurityConfig           `yaml:"security,omitempty"`
 
 	// VersionPrefix, when non-empty, becomes a URL path segment that is
 	// stripped from incoming requests before route resolution. Routes serve
@@ -168,9 +168,9 @@ type SourceConfig struct {
 	AutoBind    *bool                  `yaml:"auto_bind,omitempty"`    // Set to false to exclude from auto-table matching
 
 	// For computed sources: derive data from another source
-	GroupBy   string            `yaml:"group_by,omitempty"`   // Field to group by (e.g., "category")
-	Aggregate map[string]string `yaml:"aggregate,omitempty"`  // Field → aggregation expression (e.g., "total": "sum(amount)")
-	Filter    string            `yaml:"filter,omitempty"`     // Optional filter expression (e.g., "status = active")
+	GroupBy   string            `yaml:"group_by,omitempty"`  // Field to group by (e.g., "category")
+	Aggregate map[string]string `yaml:"aggregate,omitempty"` // Field → aggregation expression (e.g., "total": "sum(amount)")
+	Filter    string            `yaml:"filter,omitempty"`    // Optional filter expression (e.g., "status = active")
 }
 
 // RetryConfig configures retry behavior for a source
@@ -453,16 +453,21 @@ type SiteConfig struct {
 
 // NavSection represents a navigation section with pages
 type NavSection struct {
-	Title     string    `yaml:"title"`              // Section title (e.g., "Getting Started")
-	Path      string    `yaml:"path"`               // Section path (e.g., "getting-started")
-	Collapsed bool      `yaml:"collapsed"`          // Whether section is collapsed by default
-	Pages     []NavPage `yaml:"pages,omitempty"`    // Pages in this section
+	Title     string    `yaml:"title"`           // Section title (e.g., "Getting Started")
+	Path      string    `yaml:"path"`            // Section path (e.g., "getting-started")
+	Collapsed bool      `yaml:"collapsed"`       // Whether section is collapsed by default
+	Pages     []NavPage `yaml:"pages,omitempty"` // Pages in this section
 }
 
-// NavPage represents a single page in navigation
+// NavPage represents a single entry in navigation. It is either a leaf
+// (Path set, no Pages) or a collapsible group (Pages set) — or both, a
+// landing page that also owns sub-pages. Groups let a long section nest its
+// pages by category instead of rendering as one flat list.
 type NavPage struct {
-	Title string `yaml:"title"` // Page title (e.g., "Installation")
-	Path  string `yaml:"path"`  // Page path (e.g., "getting-started/installation.md")
+	Title     string    `yaml:"title"`               // Page or group title (e.g., "Installation", "Forms & Editing")
+	Path      string    `yaml:"path,omitempty"`      // Page path (e.g., "getting-started/installation.md"); empty for a pure group
+	Collapsed bool      `yaml:"collapsed,omitempty"` // For groups: whether collapsed by default
+	Pages     []NavPage `yaml:"pages,omitempty"`     // Sub-pages; presence makes this a group
 }
 
 // SecurityConfig exposes site-level security knobs that change emitted

--- a/internal/server/nested_nav_test.go
+++ b/internal/server/nested_nav_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+// Nested navigation: a section's pages may themselves be groups, so a long
+// section (e.g. UI Patterns with 33 entries) renders as collapsible category
+// sub-groups instead of one flat list. Groups + sections are native
+// <details>/<summary>, so collapse needs no JS. These tests lock the three
+// things that can silently break:
+//
+//  1. Registration — every nested leaf, at any depth, must still be served
+//     (a missed leaf in the recursion is a silent 404 in site mode).
+//  2. Structure — groups render as <details class="nav-group"> with a
+//     <summary class="nav-group-title">, while top-level sections keep
+//     class "nav-section-title" (the docs IA test counts those).
+//  3. Collapse state — a section/group is `open` when not collapsed OR when
+//     it holds the active page; otherwise closed.
+
+// renderNestedSidebar builds a site with a nested "UI Patterns" section and
+// returns the rendered HTML for the requested URL path (plus the server so a
+// caller can issue more requests).
+func renderNestedSidebar(t *testing.T, requestPath string) (body string, srv *Server, dir string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	pages := map[string]string{
+		"home.md":         "# Home",
+		"forms/click.md":  "# Click to Edit",
+		"forms/edit.md":   "# Edit Row",
+		"lists/delete.md": "# Delete Row",
+	}
+	for rel, h1 := range pages {
+		abs := filepath.Join(tmpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte("---\ntitle: T\n---\n"+h1+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Title = "Test Docs"
+	cfg.Site = &config.SiteConfig{Home: "home.md"}
+	cfg.Features.Sidebar = true
+	cfg.Navigation = []config.NavSection{
+		{
+			Title: "Top",
+			Pages: []config.NavPage{{Title: "Home", Path: "home.md"}},
+		},
+		{
+			Title:     "UI Patterns",
+			Collapsed: true,
+			Pages: []config.NavPage{
+				{
+					Title:     "Forms & Editing",
+					Collapsed: true,
+					Pages: []config.NavPage{
+						{Title: "Click to Edit", Path: "forms/click.md"},
+						{Title: "Edit Row", Path: "forms/edit.md"},
+					},
+				},
+				{
+					Title:     "Lists & Data",
+					Collapsed: true,
+					Pages:     []config.NavPage{{Title: "Delete Row", Path: "lists/delete.md"}},
+				},
+			},
+		},
+	}
+
+	srv = NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", requestPath, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200; body=%s", requestPath, w.Code, w.Body.String())
+	}
+	return w.Body.String(), srv, tmpDir
+}
+
+// TestNestedLeavesAreServed is the registration invariant: every nested leaf,
+// at any depth, resolves to 200. A regression here means deep links 404.
+func TestNestedLeavesAreServed(t *testing.T) {
+	_, srv, _ := renderNestedSidebar(t, "/forms/click")
+	for _, path := range []string{"/forms/click", "/forms/edit", "/lists/delete"} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("nested leaf %s = %d, want 200 (registration missed it)", path, w.Code)
+		}
+	}
+}
+
+// TestNestedSidebarStructure asserts groups render as <details> sub-groups
+// with the group-title class, and top-level sections keep the section-title
+// class (so the docs IA section count stays correct).
+func TestNestedSidebarStructure(t *testing.T) {
+	body, _, _ := renderNestedSidebar(t, "/forms/click")
+
+	// Two top-level sections, two category groups.
+	if got := strings.Count(body, `class="nav-section-title"`); got != 2 {
+		t.Errorf("nav-section-title count = %d, want 2 (Top, UI Patterns)", got)
+	}
+	if got := strings.Count(body, `class="nav-group-title"`); got != 2 {
+		t.Errorf("nav-group-title count = %d, want 2 (Forms, Lists)", got)
+	}
+	for _, want := range []string{
+		`<summary class="nav-section-title">UI Patterns</summary>`,
+		`<summary class="nav-group-title">Forms & Editing</summary>`,
+		`<summary class="nav-group-title">Lists & Data</summary>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("sidebar missing %q", want)
+		}
+	}
+	// The Pico-override CSS must ship, or groups inherit Pico's accordion
+	// margins/colors and the hierarchy reads wrong.
+	if !strings.Contains(body, "#tinkerdown-sidebar .nav-group-title") {
+		t.Error("nested-nav CSS override (#tinkerdown-sidebar .nav-group-title) missing")
+	}
+}
+
+// TestNestedCollapseState asserts the open/closed logic: the group + section
+// holding the active page open; sibling groups stay closed.
+func TestNestedCollapseState(t *testing.T) {
+	// Active page is /forms/click — UI Patterns + Forms open, Lists closed.
+	body, _, _ := renderNestedSidebar(t, "/forms/click")
+
+	if !strings.Contains(body, `<details class="nav-section" open><summary class="nav-section-title">UI Patterns</summary>`) {
+		t.Error("UI Patterns section should be open (holds active page)")
+	}
+	if !strings.Contains(body, `<details class="nav-group" open><summary class="nav-group-title">Forms & Editing</summary>`) {
+		t.Error("Forms group should be open (holds active page)")
+	}
+	if !strings.Contains(body, `<details class="nav-group"><summary class="nav-group-title">Lists & Data</summary>`) {
+		t.Error("Lists group should be closed (collapsed, does not hold active page)")
+	}
+
+	// Active page is /home (in Top). The collapsed UI Patterns section, and
+	// both its groups, should now be closed.
+	body2, _, _ := renderNestedSidebar(t, "/home")
+	if !strings.Contains(body2, `<details class="nav-section"><summary class="nav-section-title">UI Patterns</summary>`) {
+		t.Error("UI Patterns section should be closed when active page is elsewhere")
+	}
+	if strings.Contains(body2, `<details class="nav-group" open>`) {
+		t.Error("no group should be open when active page is outside UI Patterns")
+	}
+}

--- a/internal/server/nested_nav_test.go
+++ b/internal/server/nested_nav_test.go
@@ -122,8 +122,8 @@ func TestNestedSidebarStructure(t *testing.T) {
 	}
 	for _, want := range []string{
 		`<summary class="nav-section-title">UI Patterns</summary>`,
-		`<summary class="nav-group-title">Forms & Editing</summary>`,
-		`<summary class="nav-group-title">Lists & Data</summary>`,
+		`<summary class="nav-group-title">Forms &amp; Editing</summary>`,
+		`<summary class="nav-group-title">Lists &amp; Data</summary>`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("sidebar missing %q", want)
@@ -145,10 +145,10 @@ func TestNestedCollapseState(t *testing.T) {
 	if !strings.Contains(body, `<details class="nav-section" open><summary class="nav-section-title">UI Patterns</summary>`) {
 		t.Error("UI Patterns section should be open (holds active page)")
 	}
-	if !strings.Contains(body, `<details class="nav-group" open><summary class="nav-group-title">Forms & Editing</summary>`) {
+	if !strings.Contains(body, `<details class="nav-group" open><summary class="nav-group-title">Forms &amp; Editing</summary>`) {
 		t.Error("Forms group should be open (holds active page)")
 	}
-	if !strings.Contains(body, `<details class="nav-group"><summary class="nav-group-title">Lists & Data</summary>`) {
+	if !strings.Contains(body, `<details class="nav-group"><summary class="nav-group-title">Lists &amp; Data</summary>`) {
 		t.Error("Lists group should be closed (collapsed, does not hold active page)")
 	}
 

--- a/internal/server/nested_nav_test.go
+++ b/internal/server/nested_nav_test.go
@@ -162,3 +162,55 @@ func TestNestedCollapseState(t *testing.T) {
 		t.Error("no group should be open when active page is outside UI Patterns")
 	}
 }
+
+// TestGroupLandingPageLinkRenders verifies a group that carries its own path
+// (a landing page) renders a clickable link to it as the first item inside the
+// group, with the active class applied when that landing page is current.
+func TestGroupLandingPageLinkRenders(t *testing.T) {
+	tmpDir := t.TempDir()
+	for rel, h1 := range map[string]string{
+		"home.md": "# Home", "grp/landing.md": "# Landing", "grp/child.md": "# Child",
+	} {
+		abs := filepath.Join(tmpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte("---\ntitle: T\n---\n"+h1+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Title = "T"
+	cfg.Site = &config.SiteConfig{Home: "home.md"}
+	cfg.Features.Sidebar = true
+	cfg.Navigation = []config.NavSection{{
+		Title: "Sec",
+		Pages: []config.NavPage{
+			{Title: "Home", Path: "home.md"},
+			{Title: "Grp", Path: "grp/landing.md", Pages: []config.NavPage{
+				{Title: "Child", Path: "grp/child.md"},
+			}},
+		},
+	}}
+
+	srv := NewWithConfig(tmpDir, cfg)
+	if err := srv.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	req := httptest.NewRequest("GET", "/grp/landing", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /grp/landing = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	if !strings.Contains(body, `<a href="/grp/landing" class="nav-page-link active">Grp</a>`) {
+		t.Error("group landing page should render an active link inside its group")
+	}
+	if !strings.Contains(body, `<a href="/grp/child" class="nav-page-link">Child</a>`) {
+		t.Error("group child link missing")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2075,6 +2075,47 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             background: var(--code-bg);
         }
 
+        /* Sidebar sections and nested category groups are native
+         * <details>/<summary> elements, so they collapse with zero JS and the
+         * disclosure chevron comes free from PicoCSS's summary::after. Pico
+         * also adds bottom margins and an accordion summary color, though;
+         * these id-scoped rules clear that spacing and re-assert the sidebar's
+         * own look (the #id beats Pico's summary:not([role]) specificity). */
+        #tinkerdown-sidebar details.nav-section,
+        #tinkerdown-sidebar details.nav-group {
+            margin: 0;
+        }
+        #tinkerdown-sidebar .nav-section-title,
+        #tinkerdown-sidebar .nav-group-title {
+            cursor: pointer;
+            list-style: none;
+        }
+        #tinkerdown-sidebar details[open] > .nav-section-title,
+        #tinkerdown-sidebar details[open] > .nav-group-title {
+            margin-bottom: 0;
+        }
+        #tinkerdown-sidebar .nav-section-title {
+            color: var(--text-secondary);
+        }
+        /* Category group header: an indented sub-label under a section. */
+        #tinkerdown-sidebar .nav-group-item {
+            display: list-item;
+            margin: 0;
+            padding: 0;
+        }
+        #tinkerdown-sidebar .nav-group-title {
+            padding: 0.65rem 2.5rem 0.65rem 3rem;
+            font-size: 0.78rem;
+            font-weight: 600;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+        }
+        /* Indent leaf links inside a group so the hierarchy reads at a glance. */
+        #tinkerdown-sidebar .nav-group .nav-pages li a {
+            padding-left: 3.75rem;
+        }
+
         .nav-pages {
             /* Override PicoCSS nav ul { display: flex } which would otherwise
              * lay out nav items horizontally and crush them in the sidebar. */
@@ -3541,24 +3582,23 @@ func (s *Server) renderSidebar(currentPath string) string {
 		html.WriteString(`<button type="button" class="search-button" data-search-button aria-label="Search docs"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg><span>Search</span><kbd>⌘K</kbd></button>`)
 	}
 
-	// Navigation sections
+	// Navigation sections. Each section is a native <details> so it can
+	// collapse — honoring `collapsed` in the config, and forced open when it
+	// holds the active page so deep links never land inside a closed section.
+	// Nested groups (categories) recurse through the same mechanism.
 	for _, section := range nav {
-		html.WriteString(`<div class="nav-section">`)
-		html.WriteString(fmt.Sprintf(`<div class="nav-section-title">%s</div>`, section.Title))
+		openAttr := ""
+		if !section.Collapsed || section.ContainsPath(currentPath) {
+			openAttr = " open"
+		}
+		html.WriteString(fmt.Sprintf(`<details class="nav-section"%s>`, openAttr))
+		html.WriteString(fmt.Sprintf(`<summary class="nav-section-title">%s</summary>`, section.Title))
 
 		if len(section.Children) > 0 {
-			html.WriteString(`<ul class="nav-pages">`)
-			for _, page := range section.Children {
-				activeClass := ""
-				if page.Path == currentPath {
-					activeClass = " active"
-				}
-				html.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, page.Path, activeClass, page.Title))
-			}
-			html.WriteString(`</ul>`)
+			writeNavChildren(&html, section.Children, currentPath)
 		}
 
-		html.WriteString(`</div>`)
+		html.WriteString(`</details>`)
 	}
 
 	html.WriteString(`</nav>`)
@@ -3592,6 +3632,34 @@ func (s *Server) renderSidebar(currentPath string) string {
 	})();</script>`)
 
 	return html.String()
+}
+
+// writeNavChildren renders a list of nav nodes into b, recursing into groups.
+// A node with children becomes a collapsible <details> group; a leaf becomes a
+// link. Groups open when not collapsed, or when they hold the active page.
+func writeNavChildren(b *strings.Builder, nodes []*site.PageNode, currentPath string) {
+	b.WriteString(`<ul class="nav-pages">`)
+	for _, node := range nodes {
+		if len(node.Children) > 0 {
+			openAttr := ""
+			if !node.Collapsed || node.ContainsPath(currentPath) {
+				openAttr = " open"
+			}
+			b.WriteString(`<li class="nav-group-item">`)
+			b.WriteString(fmt.Sprintf(`<details class="nav-group"%s>`, openAttr))
+			b.WriteString(fmt.Sprintf(`<summary class="nav-group-title">%s</summary>`, node.Title))
+			writeNavChildren(b, node.Children, currentPath)
+			b.WriteString(`</details></li>`)
+			continue
+		}
+
+		activeClass := ""
+		if node.Path == currentPath {
+			activeClass = " active"
+		}
+		b.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, node.Path, activeClass, node.Title))
+	}
+	b.WriteString(`</ul>`)
 }
 
 // renderBreadcrumbs renders breadcrumb navigation

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2087,6 +2087,9 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
         #tinkerdown-sidebar .nav-section-title,
         #tinkerdown-sidebar .nav-group-title {
             cursor: pointer;
+            /* Pico already suppresses the native disclosure triangle and draws
+             * its own chevron via summary::after — which we keep. list-style
+             * only clears the list-item bullet. */
             list-style: none;
         }
         #tinkerdown-sidebar details[open] > .nav-section-title,
@@ -3657,8 +3660,9 @@ func writeNavChildren(b *strings.Builder, nodes []*site.PageNode, currentPath st
 			continue
 		}
 
-		// A node with neither a path nor children is a malformed config entry;
-		// rendering it would emit <a href=""> — a dead link to the site root.
+		// Defense-in-depth: a path-less leaf would emit <a href=""> (a dead
+		// link to root). Discover already rejects such entries, so this only
+		// guards against a future code path that builds one directly.
 		if node.Path == "" {
 			continue
 		}
@@ -3667,7 +3671,7 @@ func writeNavChildren(b *strings.Builder, nodes []*site.PageNode, currentPath st
 		if node.Path == currentPath {
 			activeClass = " active"
 		}
-		b.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, node.Path, activeClass, escapeHTML(node.Title)))
+		b.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, escapeHTML(node.Path), activeClass, escapeHTML(node.Title)))
 	}
 	b.WriteString(`</ul>`)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2084,14 +2084,9 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
         #tinkerdown-sidebar details.nav-group {
             margin: 0;
         }
-        #tinkerdown-sidebar .nav-section-title,
-        #tinkerdown-sidebar .nav-group-title {
-            cursor: pointer;
-            /* Pico already suppresses the native disclosure triangle and draws
-             * its own chevron via summary::after — which we keep. list-style
-             * only clears the list-item bullet. */
-            list-style: none;
-        }
+        /* Pico already styles <summary> with cursor:pointer, suppresses the
+         * native disclosure triangle, and draws its own chevron via
+         * summary::after — which we keep. Nothing extra needed here. */
         #tinkerdown-sidebar details[open] > .nav-section-title,
         #tinkerdown-sidebar details[open] > .nav-group-title {
             margin-bottom: 0;
@@ -3641,37 +3636,54 @@ func (s *Server) renderSidebar(currentPath string) string {
 // strings.Builder shadows the stdlib html package).
 func escapeHTML(s string) string { return html.EscapeString(s) }
 
-// writeNavChildren renders a list of nav nodes into b, recursing into groups.
-// A node with children becomes a collapsible <details> group; a leaf becomes a
-// link. Groups open when not collapsed, or when they hold the active page.
+// writeNavLink writes one <li> link for a node, marking it active when it is
+// the current page.
+func writeNavLink(b *strings.Builder, node *site.PageNode, currentPath string) {
+	activeClass := ""
+	if node.Path == currentPath {
+		activeClass = " active"
+	}
+	b.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, escapeHTML(node.Path), activeClass, escapeHTML(node.Title)))
+}
+
+// writeNavNode renders a single nav node as an <li>. A node with children is a
+// collapsible <details> group (open when not collapsed or when it holds the
+// active page); a node with a path is a link. A group that also has a path
+// contributes a link to its own landing page as the first item in the group.
+func writeNavNode(b *strings.Builder, node *site.PageNode, currentPath string) {
+	if len(node.Children) > 0 {
+		openAttr := ""
+		if !node.Collapsed || node.ContainsPath(currentPath) {
+			openAttr = " open"
+		}
+		b.WriteString(`<li class="nav-group-item">`)
+		b.WriteString(fmt.Sprintf(`<details class="nav-group"%s>`, openAttr))
+		b.WriteString(fmt.Sprintf(`<summary class="nav-group-title">%s</summary>`, escapeHTML(node.Title)))
+		b.WriteString(`<ul class="nav-pages">`)
+		if node.Path != "" {
+			writeNavLink(b, node, currentPath)
+		}
+		for _, child := range node.Children {
+			writeNavNode(b, child, currentPath)
+		}
+		b.WriteString(`</ul></details></li>`)
+		return
+	}
+
+	// Defense-in-depth: a path-less leaf would emit <a href=""> (a dead link
+	// to root). Discover already rejects such entries, so this only guards
+	// against a future code path that builds one directly.
+	if node.Path == "" {
+		return
+	}
+	writeNavLink(b, node, currentPath)
+}
+
+// writeNavChildren renders a list of nav nodes into b as a <ul>.
 func writeNavChildren(b *strings.Builder, nodes []*site.PageNode, currentPath string) {
 	b.WriteString(`<ul class="nav-pages">`)
 	for _, node := range nodes {
-		if len(node.Children) > 0 {
-			openAttr := ""
-			if !node.Collapsed || node.ContainsPath(currentPath) {
-				openAttr = " open"
-			}
-			b.WriteString(`<li class="nav-group-item">`)
-			b.WriteString(fmt.Sprintf(`<details class="nav-group"%s>`, openAttr))
-			b.WriteString(fmt.Sprintf(`<summary class="nav-group-title">%s</summary>`, escapeHTML(node.Title)))
-			writeNavChildren(b, node.Children, currentPath)
-			b.WriteString(`</details></li>`)
-			continue
-		}
-
-		// Defense-in-depth: a path-less leaf would emit <a href=""> (a dead
-		// link to root). Discover already rejects such entries, so this only
-		// guards against a future code path that builds one directly.
-		if node.Path == "" {
-			continue
-		}
-
-		activeClass := ""
-		if node.Path == currentPath {
-			activeClass = " active"
-		}
-		b.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, escapeHTML(node.Path), activeClass, escapeHTML(node.Title)))
+		writeNavNode(b, node, currentPath)
 	}
 	b.WriteString(`</ul>`)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2075,12 +2075,11 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
             background: var(--code-bg);
         }
 
-        /* Sidebar sections and nested category groups are native
-         * <details>/<summary> elements, so they collapse with zero JS and the
-         * disclosure chevron comes free from PicoCSS's summary::after. Pico
-         * also adds bottom margins and an accordion summary color, though;
-         * these id-scoped rules clear that spacing and re-assert the sidebar's
-         * own look (the #id beats Pico's summary:not([role]) specificity). */
+        /* Sections + groups are native <details>/<summary> (zero-JS collapse;
+         * chevron comes free from Pico's summary::after). Pico also adds
+         * details margins and an accordion summary color — these id-scoped
+         * rules clear that spacing and re-assert the sidebar's own look (the
+         * #id beats Pico's summary:not([role]) specificity). */
         #tinkerdown-sidebar details.nav-section,
         #tinkerdown-sidebar details.nav-group {
             margin: 0;
@@ -3592,7 +3591,7 @@ func (s *Server) renderSidebar(currentPath string) string {
 			openAttr = " open"
 		}
 		html.WriteString(fmt.Sprintf(`<details class="nav-section"%s>`, openAttr))
-		html.WriteString(fmt.Sprintf(`<summary class="nav-section-title">%s</summary>`, section.Title))
+		html.WriteString(fmt.Sprintf(`<summary class="nav-section-title">%s</summary>`, escapeHTML(section.Title)))
 
 		if len(section.Children) > 0 {
 			writeNavChildren(&html, section.Children, currentPath)
@@ -3634,6 +3633,11 @@ func (s *Server) renderSidebar(currentPath string) string {
 	return html.String()
 }
 
+// escapeHTML HTML-escapes a string for safe interpolation into nav markup.
+// Defined at package scope (not inside renderSidebar, where the local `html`
+// strings.Builder shadows the stdlib html package).
+func escapeHTML(s string) string { return html.EscapeString(s) }
+
 // writeNavChildren renders a list of nav nodes into b, recursing into groups.
 // A node with children becomes a collapsible <details> group; a leaf becomes a
 // link. Groups open when not collapsed, or when they hold the active page.
@@ -3647,9 +3651,15 @@ func writeNavChildren(b *strings.Builder, nodes []*site.PageNode, currentPath st
 			}
 			b.WriteString(`<li class="nav-group-item">`)
 			b.WriteString(fmt.Sprintf(`<details class="nav-group"%s>`, openAttr))
-			b.WriteString(fmt.Sprintf(`<summary class="nav-group-title">%s</summary>`, node.Title))
+			b.WriteString(fmt.Sprintf(`<summary class="nav-group-title">%s</summary>`, escapeHTML(node.Title)))
 			writeNavChildren(b, node.Children, currentPath)
 			b.WriteString(`</details></li>`)
+			continue
+		}
+
+		// A node with neither a path nor children is a malformed config entry;
+		// rendering it would emit <a href=""> — a dead link to the site root.
+		if node.Path == "" {
 			continue
 		}
 
@@ -3657,7 +3667,7 @@ func writeNavChildren(b *strings.Builder, nodes []*site.PageNode, currentPath st
 		if node.Path == currentPath {
 			activeClass = " active"
 		}
-		b.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, node.Path, activeClass, node.Title))
+		b.WriteString(fmt.Sprintf(`<li><a href="%s" class="nav-page-link%s">%s</a></li>`, node.Path, activeClass, escapeHTML(node.Title)))
 	}
 	b.WriteString(`</ul>`)
 }

--- a/internal/site/manager.go
+++ b/internal/site/manager.go
@@ -119,6 +119,12 @@ func (m *Manager) discoverFromConfig() error {
 // whose Children are built recursively (a group may also carry its own Path,
 // acting as a landing page for the group).
 func (m *Manager) buildNavPageNode(page config.NavPage) (*PageNode, error) {
+	// A nav entry with neither a path nor sub-pages is meaningless and would
+	// otherwise vanish silently from the sidebar — fail fast on the typo.
+	if page.Path == "" && len(page.Pages) == 0 {
+		return nil, fmt.Errorf("nav entry %q has neither a path nor pages", page.Title)
+	}
+
 	node := &PageNode{
 		Title:     page.Title,
 		Collapsed: page.Collapsed,

--- a/internal/site/manager.go
+++ b/internal/site/manager.go
@@ -12,12 +12,28 @@ import (
 
 // PageNode represents a page in the site structure
 type PageNode struct {
-	Title    string      // Page title from frontmatter or config
-	Path     string      // URL path (e.g., "/getting-started/installation")
-	FilePath string      // Relative file path (e.g., "getting-started/installation.md")
-	Page     *tinkerdown.Page // Parsed page content
-	IsHome   bool        // Whether this is the home page
-	Children []*PageNode // Child pages (for sections)
+	Title     string           // Page title from frontmatter or config
+	Path      string           // URL path (e.g., "/getting-started/installation")
+	FilePath  string           // Relative file path (e.g., "getting-started/installation.md")
+	Page      *tinkerdown.Page // Parsed page content
+	IsHome    bool             // Whether this is the home page
+	Collapsed bool             // For sections/groups: whether collapsed by default
+	Children  []*PageNode      // Child pages (for sections and groups)
+}
+
+// ContainsPath reports whether this node or any descendant has the given URL
+// path. Used to keep a collapsed section/group open when it holds the active
+// page, and to resolve a nested page's section in the search index.
+func (n *PageNode) ContainsPath(urlPath string) bool {
+	if n.Path == urlPath {
+		return true
+	}
+	for _, child := range n.Children {
+		if child.ContainsPath(urlPath) {
+			return true
+		}
+	}
+	return false
 }
 
 // Manager handles multi-page site discovery and navigation
@@ -54,45 +70,19 @@ func (m *Manager) Discover() error {
 func (m *Manager) discoverFromConfig() error {
 	for _, section := range m.config.Navigation {
 		sectionNode := &PageNode{
-			Title:    section.Title,
-			Path:     "/" + section.Path,
-			Children: make([]*PageNode, 0),
+			Title:     section.Title,
+			Path:      "/" + section.Path,
+			Collapsed: section.Collapsed,
+			Children:  make([]*PageNode, 0),
 		}
 
-		// Process pages in this section
+		// Process pages in this section (each may itself be a group of pages)
 		for _, page := range section.Pages {
-			// Resolve file path
-			filePath := page.Path
-			if !strings.HasSuffix(filePath, ".md") {
-				filePath += ".md"
-			}
-
-			absPath := filepath.Join(m.rootDir, filePath)
-
-			// Parse the page
-			parsed, err := tinkerdown.ParseFileInSite(absPath, m.rootDir)
+			child, err := m.buildNavPageNode(page)
 			if err != nil {
-				return fmt.Errorf("failed to parse %s: %w", filePath, err)
+				return err
 			}
-
-			// Generate URL path
-			urlPath := mdToURLPath(filePath)
-
-			pageNode := &PageNode{
-				Title:    page.Title,
-				Path:     urlPath,
-				FilePath: filePath,
-				Page:     parsed,
-			}
-
-			// Check if this is the home page
-			if m.config.Site != nil && filePath == m.config.Site.Home {
-				pageNode.IsHome = true
-				m.home = pageNode
-			}
-
-			sectionNode.Children = append(sectionNode.Children, pageNode)
-			m.pages[urlPath] = pageNode
+			sectionNode.Children = append(sectionNode.Children, child)
 		}
 
 		m.nav = append(m.nav, sectionNode)
@@ -120,6 +110,53 @@ func (m *Manager) discoverFromConfig() error {
 	}
 
 	return nil
+}
+
+// buildNavPageNode builds a PageNode for one nav entry, recursing into any
+// sub-pages. An entry with a Path is parsed and registered in m.pages so the
+// site server will serve it — this registration must reach every leaf at any
+// depth, or a nested page silently 404s. An entry with Pages becomes a group
+// whose Children are built recursively (a group may also carry its own Path,
+// acting as a landing page for the group).
+func (m *Manager) buildNavPageNode(page config.NavPage) (*PageNode, error) {
+	node := &PageNode{
+		Title:     page.Title,
+		Collapsed: page.Collapsed,
+	}
+
+	if page.Path != "" {
+		filePath := page.Path
+		if !strings.HasSuffix(filePath, ".md") {
+			filePath += ".md"
+		}
+
+		absPath := filepath.Join(m.rootDir, filePath)
+		parsed, err := tinkerdown.ParseFileInSite(absPath, m.rootDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", filePath, err)
+		}
+
+		node.Path = mdToURLPath(filePath)
+		node.FilePath = filePath
+		node.Page = parsed
+
+		if m.config.Site != nil && filePath == m.config.Site.Home {
+			node.IsHome = true
+			m.home = node
+		}
+
+		m.pages[node.Path] = node
+	}
+
+	for _, sub := range page.Pages {
+		child, err := m.buildNavPageNode(sub)
+		if err != nil {
+			return nil, err
+		}
+		node.Children = append(node.Children, child)
+	}
+
+	return node, nil
 }
 
 // discoverFromFiles auto-discovers pages from directory structure
@@ -423,16 +460,12 @@ func (m *Manager) GenerateSearchIndex() []SearchEntry {
 		// Extract text content from the page
 		content := extractTextContent(page.Page)
 
-		// Find the section this page belongs to
+		// Find the top-level section this page belongs to, searching the
+		// whole subtree so nested (grouped) pages still resolve their section.
 		section := ""
 		for _, navNode := range m.nav {
-			for _, child := range navNode.Children {
-				if child.Path == page.Path {
-					section = navNode.Title
-					break
-				}
-			}
-			if section != "" {
+			if navNode.ContainsPath(page.Path) {
+				section = navNode.Title
 				break
 			}
 		}

--- a/internal/site/manager_test.go
+++ b/internal/site/manager_test.go
@@ -1,0 +1,111 @@
+package site
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/livetemplate/tinkerdown/internal/config"
+)
+
+// writeNavSite creates a tmp site with the given relative .md files (each gets
+// a trivial body) and returns a discovered Manager for cfg.
+func writeNavSite(t *testing.T, cfg *config.Config, files ...string) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	for _, rel := range files {
+		abs := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte("---\ntitle: T\n---\n# "+rel+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := New(dir, cfg)
+	if err := m.Discover(); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	return m
+}
+
+// TestNestedRegistrationAndSearchSection covers two things the recursive nav
+// builder must get right at depth: (1) a leaf three levels deep (section →
+// group → subgroup → leaf) is still registered/served, and (2) the search
+// index resolves that nested leaf back to its top-level section title.
+func TestNestedRegistrationAndSearchSection(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Title = "T"
+	cfg.Site = &config.SiteConfig{Home: "home.md"}
+	cfg.Navigation = []config.NavSection{
+		{
+			Title: "Patterns",
+			Pages: []config.NavPage{
+				{Title: "Home", Path: "home.md"},
+				{
+					Title: "Forms",
+					Pages: []config.NavPage{
+						{
+							Title: "Advanced",
+							Pages: []config.NavPage{
+								{Title: "Deep Leaf", Path: "forms/advanced/deep.md"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := writeNavSite(t, cfg, "home.md", "forms/advanced/deep.md")
+
+	// Depth-3 leaf registered.
+	if _, ok := m.GetPage("/forms/advanced/deep"); !ok {
+		t.Fatal("depth-3 nested leaf /forms/advanced/deep not registered")
+	}
+
+	// Search index resolves it to the top-level section.
+	var got string
+	for _, e := range m.GenerateSearchIndex() {
+		if e.Path == "/forms/advanced/deep" {
+			got = e.Section
+		}
+	}
+	if got != "Patterns" {
+		t.Errorf("search section for nested leaf = %q, want %q", got, "Patterns")
+	}
+}
+
+// TestGroupWithLandingPage covers a group entry that carries both a Path (its
+// own landing page) and Pages (children): both the landing page and the
+// children must be served.
+func TestGroupWithLandingPage(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Title = "T"
+	cfg.Site = &config.SiteConfig{Home: "home.md"}
+	cfg.Navigation = []config.NavSection{
+		{
+			Title: "Sec",
+			Pages: []config.NavPage{
+				{Title: "Home", Path: "home.md"},
+				{
+					Title: "Group",
+					Path:  "group/landing.md", // landing page for the group
+					Pages: []config.NavPage{
+						{Title: "Child", Path: "group/child.md"},
+					},
+				},
+			},
+		},
+	}
+
+	m := writeNavSite(t, cfg, "home.md", "group/landing.md", "group/child.md")
+
+	for _, want := range []string{"/group/landing", "/group/child"} {
+		if _, ok := m.GetPage(want); !ok {
+			t.Errorf("page %s not registered (group landing-page + children must both serve)", want)
+		}
+	}
+}

--- a/internal/site/manager_test.go
+++ b/internal/site/manager_test.go
@@ -77,6 +77,26 @@ func TestNestedRegistrationAndSearchSection(t *testing.T) {
 	}
 }
 
+// TestEmptyNavEntryErrors verifies a malformed nav entry — neither path nor
+// pages — fails Discover loudly rather than vanishing from the sidebar.
+func TestEmptyNavEntryErrors(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Title = "T"
+	cfg.Site = &config.SiteConfig{Home: "home.md"}
+	cfg.Navigation = []config.NavSection{
+		{Title: "Sec", Pages: []config.NavPage{{Title: "Broken"}}},
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "home.md"), []byte("# Home\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := New(dir, cfg).Discover(); err == nil {
+		t.Fatal("Discover should error on a nav entry with neither path nor pages")
+	}
+}
+
 // TestGroupWithLandingPage covers a group entry that carries both a Path (its
 // own landing page) and Pages (children): both the landing page and the
 // children must be served.


### PR DESCRIPTION
## What

A nav section's pages can now themselves be **groups**, so a long section renders as collapsible category sub-groups instead of one flat list. Sections and groups are native `<details>/<summary>`, so collapse needs **zero JS** and the disclosure chevron comes free from PicoCSS.

Motivated by the docs site's "UI Patterns" section, which lists 33 pattern pages as a single flat sidebar list. With this, they nest under their 7 categories.

## Changes

- **config** (`internal/config/config.go`): `NavPage` gains `Pages` (recursive) + `Collapsed`. Presence of `Pages` makes an entry a group. Backward compatible — existing flat configs leave `Pages` empty.
- **site** (`internal/site/manager.go`): `discoverFromConfig` recurses via `buildNavPageNode`, registering **every nested leaf** in `m.pages` (the registration invariant — a missed leaf 303s to home in site mode). `PageNode` gains `Collapsed` + `ContainsPath`; the search-index section lookup now descends the whole subtree.
- **server** (`internal/server/server.go`): `renderSidebar` emits sections + groups as `<details>` honoring `collapsed` and **auto-opening** the branch that holds the active page. Pico's `<details>` margins/colors are neutralized with id-scoped overrides; top-level summaries keep `class="nav-section-title"`, groups use `nav-group-title`.

## Tests

`internal/server/nested_nav_test.go`: nested leaves serve 200, group/section structure + classes, and collapse/auto-open state. Full CI suite (`go test -tags=ci -skip='E2E|e2e' ./...`) green.

## Verification

Built the docs site against this branch and verified in a real browser (chromedp): UI Patterns → 7 collapsible category groups, active category auto-opens, all 33 leaves serve 200, top-level IA section count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)