### PR TITLE
Fix breadcrumb section pills 303-redirecting to the home page

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3717,13 +3717,13 @@ func (s *Server) renderBreadcrumbs(currentPath string) string {
 			// Link only when the path resolves to a real page; otherwise render
 			// a plain label so the crumb never 303-redirects to the home page.
 			if href, ok := s.siteManager.ResolveBreadcrumbHref(crumb.Path); ok {
-				html.WriteString(fmt.Sprintf(`<li><a href="%s">%s</a></li>`, href, crumb.Title))
+				html.WriteString(fmt.Sprintf(`<li><a href="%s">%s</a></li>`, escapeHTML(href), escapeHTML(crumb.Title)))
 			} else {
-				html.WriteString(fmt.Sprintf(`<li class="crumb-label">%s</li>`, crumb.Title))
+				html.WriteString(fmt.Sprintf(`<li class="crumb-label">%s</li>`, escapeHTML(crumb.Title)))
 			}
 			html.WriteString(`<li class="separator">›</li>`)
 		} else {
-			html.WriteString(fmt.Sprintf(`<li class="current">%s</li>`, crumb.Title))
+			html.WriteString(fmt.Sprintf(`<li class="current">%s</li>`, escapeHTML(crumb.Title)))
 		}
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2249,10 +2249,17 @@ func (s *Server) renderPage(page *tinkerdown.Page, currentPath string, host stri
 
         .breadcrumbs a,
         .breadcrumbs .current,
+        .breadcrumbs .crumb-label,
         .breadcrumbs .separator {
             font-size: 0.9rem;
             line-height: 1.5;
             vertical-align: baseline;
+        }
+
+        /* A section crumb with no servable page renders as muted, non-clickable
+           text rather than a link that would 303 to the home page. */
+        .breadcrumbs .crumb-label {
+            color: var(--text-secondary);
         }
 
         .breadcrumbs a {
@@ -3704,7 +3711,16 @@ func (s *Server) renderBreadcrumbs(currentPath string) string {
 
 	for i, crumb := range breadcrumbs {
 		if i < len(breadcrumbs)-1 {
-			html.WriteString(fmt.Sprintf(`<li><a href="%s">%s</a></li>`, crumb.Path, crumb.Title))
+			// Intermediate crumbs are section/group nodes whose stored path may
+			// be a non-routable directory (e.g. "/recipes" when the index page
+			// is served at "/recipes/", or a section with no index page at all).
+			// Link only when the path resolves to a real page; otherwise render
+			// a plain label so the crumb never 303-redirects to the home page.
+			if href, ok := s.siteManager.ResolveBreadcrumbHref(crumb.Path); ok {
+				html.WriteString(fmt.Sprintf(`<li><a href="%s">%s</a></li>`, href, crumb.Title))
+			} else {
+				html.WriteString(fmt.Sprintf(`<li class="crumb-label">%s</li>`, crumb.Title))
+			}
 			html.WriteString(`<li class="separator">›</li>`)
 		} else {
 			html.WriteString(fmt.Sprintf(`<li class="current">%s</li>`, crumb.Title))

--- a/internal/site/manager.go
+++ b/internal/site/manager.go
@@ -413,6 +413,25 @@ func (m *Manager) GetBreadcrumbs(urlPath string) []*PageNode {
 	return breadcrumbs
 }
 
+// ResolveBreadcrumbHref maps a breadcrumb crumb's stored path to a servable
+// URL. Section/group crumbs carry a directory-style path (e.g. "/recipes") that
+// is not itself a route: index pages register with a trailing slash
+// ("/recipes/"), and some sections have no index page at all. It returns the
+// path unchanged when a page is registered there, falls back to the index route
+// (path + "/") when only that exists, and reports ok=false when nothing is
+// servable — so the caller can render a plain label instead of a link that
+// would 303-redirect back to the home page.
+func (m *Manager) ResolveBreadcrumbHref(path string) (string, bool) {
+	if _, ok := m.GetPage(path); ok {
+		return path, true
+	}
+	withSlash := strings.TrimSuffix(path, "/") + "/"
+	if _, ok := m.GetPage(withSlash); ok {
+		return withSlash, true
+	}
+	return "", false
+}
+
 // Reload reloads a specific file (for hot reload)
 func (m *Manager) Reload(filePath string) error {
 	// Get relative path

--- a/internal/site/manager.go
+++ b/internal/site/manager.go
@@ -425,6 +425,9 @@ func (m *Manager) ResolveBreadcrumbHref(path string) (string, bool) {
 	if _, ok := m.GetPage(path); ok {
 		return path, true
 	}
+	// Section crumbs store a slash-less directory path; its index page is served
+	// at that path + "/". TrimSuffix first so a caller that already passes a
+	// trailing slash doesn't produce a doubled "//".
 	withSlash := strings.TrimSuffix(path, "/") + "/"
 	if _, ok := m.GetPage(withSlash); ok {
 		return withSlash, true

--- a/internal/site/manager_test.go
+++ b/internal/site/manager_test.go
@@ -170,6 +170,7 @@ func TestResolveBreadcrumbHref(t *testing.T) {
 		wantOK   bool
 	}{
 		{"index served at trailing slash", "/recipes", "/recipes/", true},
+		{"path already has trailing slash", "/recipes/", "/recipes/", true},
 		{"section without index page", "/getting-started", "", false},
 		{"path is already a page", "/recipes/foo", "/recipes/foo", true},
 		{"home root", "/", "/", true},

--- a/internal/site/manager_test.go
+++ b/internal/site/manager_test.go
@@ -129,3 +129,58 @@ func TestGroupWithLandingPage(t *testing.T) {
 		}
 	}
 }
+
+// TestResolveBreadcrumbHref covers the three crumb shapes the breadcrumb
+// renderer must distinguish so a section pill never 303-redirects to home:
+// (1) a section whose only page is an index, served at a trailing slash
+// ("recipes/index.md" → "/recipes/") — the bare "/recipes" crumb must resolve
+// to "/recipes/"; (2) a section with no index page at all — must report
+// not-found so the renderer emits a plain label; (3) a path that is already a
+// real page — returned unchanged.
+func TestResolveBreadcrumbHref(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Type = "site"
+	cfg.Title = "T"
+	cfg.Site = &config.SiteConfig{Home: "index.md"} // home served at "/"
+	cfg.Navigation = []config.NavSection{
+		{
+			Title: "Recipes",
+			Path:  "recipes", // section dir, not itself a route
+			Pages: []config.NavPage{
+				{Title: "Overview", Path: "recipes/index.md"},
+				{Title: "Foo", Path: "recipes/foo.md"},
+			},
+		},
+		{
+			Title: "Learn",
+			Path:  "getting-started", // no index page under it
+			Pages: []config.NavPage{
+				{Title: "Intro", Path: "getting-started/intro.md"},
+			},
+		},
+	}
+
+	m := writeNavSite(t, cfg,
+		"index.md", "recipes/index.md", "recipes/foo.md", "getting-started/intro.md")
+
+	cases := []struct {
+		name     string
+		path     string
+		wantHref string
+		wantOK   bool
+	}{
+		{"index served at trailing slash", "/recipes", "/recipes/", true},
+		{"section without index page", "/getting-started", "", false},
+		{"path is already a page", "/recipes/foo", "/recipes/foo", true},
+		{"home root", "/", "/", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			href, ok := m.ResolveBreadcrumbHref(tc.path)
+			if ok != tc.wantOK || href != tc.wantHref {
+				t.Errorf("ResolveBreadcrumbHref(%q) = (%q, %v), want (%q, %v)",
+					tc.path, href, ok, tc.wantHref, tc.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Clicking a category pill in the breadcrumb trail (Learn, Concepts, Recipes, Apps, UI Patterns, …) navigated to the home/landing page instead of the category index.

Intermediate breadcrumb crumbs are section/group nodes whose stored path is a **directory** (e.g. `/recipes`) that is not itself a served route:

- index pages register with a **trailing slash** (`recipes/index.md` → `/recipes/`), so the bare `/recipes` has no route;
- some sections have **no index page at all** (e.g. `/getting-started`).

`renderBreadcrumbs` linked the bare path directly, so the click hit site mode's unknown-path handler, which 303-redirects to the first route (the landing page).

## Fix

Resolve each non-final crumb to its real servable route **at render time** via the new `Manager.ResolveBreadcrumbHref`:

1. exact match → link as-is;
2. else the trailing-slash index route (`path + "/"`) → link to that;
3. else not-found → render a plain, non-clickable label so a section without any index page never redirects.

The node's stored `Path` is intentionally **left untouched** — `GetBreadcrumbs` matches `navNode.Path == currentPath` against a slash-less `currentPath`, so mutating the path would break crumb detection. Resolution happens only when emitting the link.

The sidebar is unaffected: top-level sections already render as non-link `<summary>` toggles, and nested groups in practice carry no path.

## Tests

- `TestResolveBreadcrumbHref` covers the three crumb shapes (trailing-slash index, no-index label, exact page) + home root.
- `internal/site` and `internal/server` suites pass.

Verified end-to-end against a local build serving the docs `content/` (every pill now links to its index route or renders as a non-redirecting label), with a chromedp click-through in the companion docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)