### PR TITLE
fix(server): proxy routes forward WebSocket upgrades (rewrite Origin) (#257)

### DIFF
--- a/docs/sources/embed-lvt.md
+++ b/docs/sources/embed-lvt.md
@@ -88,6 +88,15 @@ routes:
 Then any `embed-lvt path="/apps/counter/"` block on any docs page
 reaches the counter app on port 9090 with zero CORS configuration.
 
+> **Security note — Origin rewriting.** For the upstream's same-origin
+> WebSocket check to accept proxied handshakes, tinkerdown rewrites the
+> `Origin` header on WebSocket upgrade requests to the upstream's own
+> origin (non-WebSocket requests are untouched). This means the upstream
+> sees its own origin, not the real browser origin. An upstream that uses
+> the `Origin` header for *authorization* (rather than just same-origin
+> CSRF protection) should not be fronted by a proxy route without
+> additional authentication.
+
 ## Cross-origin (sibling subdomain)
 
 If your upstream app is on a different host, two things are needed:

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -60,8 +60,11 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 		// same-origin WebSocket check would 403 a handshake whose Origin
 		// still names the proxy. Present the upstream origin instead — but
 		// only for WS upgrades, since non-WS CORS must keep the real Origin.
-		// (An upstream that allow-lists the proxy's own origin rather than
-		// its host would still reject; that config is uncommon.)
+		//
+		// Security contract: this hides the real browser origin from the
+		// upstream. An upstream that uses Origin for authorization (not just
+		// same-origin checking) should not be fronted by this proxy without
+		// additional authentication.
 		if isWebSocketUpgrade(req) && req.Header.Get("Origin") != "" {
 			req.Header.Set("Origin", upstreamOrigin)
 		}

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -81,7 +81,8 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 // isWebSocketUpgrade reports whether req is a WebSocket upgrade handshake.
 // Connection may arrive as multiple header lines, each a comma-separated
 // token list (e.g. "keep-alive, Upgrade"), so we scan every token across
-// all lines rather than compare whole.
+// all lines rather than compare whole. (strings.SplitSeq is a Go 1.24+
+// iterator; this module requires 1.26 — see go.mod.)
 func isWebSocketUpgrade(req *http.Request) bool {
 	if !strings.EqualFold(req.Header.Get("Upgrade"), "websocket") {
 		return false

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -79,15 +79,18 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 }
 
 // isWebSocketUpgrade reports whether req is a WebSocket upgrade handshake.
-// The Connection header may be a comma-separated token list (e.g.
-// "keep-alive, Upgrade"), so we scan its tokens rather than compare whole.
+// Connection may arrive as multiple header lines, each a comma-separated
+// token list (e.g. "keep-alive, Upgrade"), so we scan every token across
+// all lines rather than compare whole.
 func isWebSocketUpgrade(req *http.Request) bool {
 	if !strings.EqualFold(req.Header.Get("Upgrade"), "websocket") {
 		return false
 	}
-	for tok := range strings.SplitSeq(req.Header.Get("Connection"), ",") {
-		if strings.EqualFold(strings.TrimSpace(tok), "upgrade") {
-			return true
+	for _, line := range req.Header.Values("Connection") {
+		for tok := range strings.SplitSeq(line, ",") {
+			if strings.EqualFold(strings.TrimSpace(tok), "upgrade") {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -84,6 +84,12 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 // all lines rather than compare whole. (strings.SplitSeq is a Go 1.24+
 // iterator; this module requires 1.26 — see go.mod.)
 func isWebSocketUpgrade(req *http.Request) bool {
+	// RFC 6455 §4.1: the opening handshake is a GET. Guarding on the method
+	// keeps the helper's intent precise (a non-GET with Upgrade headers is
+	// not a real handshake and shouldn't have its Origin rewritten).
+	if req.Method != http.MethodGet {
+		return false
+	}
 	if !strings.EqualFold(req.Header.Get("Upgrade"), "websocket") {
 		return false
 	}

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -15,7 +15,9 @@ import (
 // proxyRoute is the runtime representation of a config.RouteEntry with
 // type=proxy. It pairs a path matcher with a configured reverse-proxy
 // handler. WebSocket upgrades are forwarded automatically by the stdlib
-// reverse proxy (Go 1.12+).
+// reverse proxy (Go 1.12+); the Director additionally rewrites the Origin
+// header to the upstream origin on WS handshakes so the upstream's
+// same-origin check accepts the proxied connection (see Director below).
 type proxyRoute struct {
 	pattern  string
 	isPrefix bool
@@ -42,6 +44,7 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 
 	rp := httputil.NewSingleHostReverseProxy(u)
 	origDirector := rp.Director
+	upstreamOrigin := u.Scheme + "://" + u.Host
 	rp.Director = func(req *http.Request) {
 		// Save Path AND RawPath before the default Director runs.
 		// NewSingleHostReverseProxy's default Director joins
@@ -53,6 +56,15 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 		origDirector(req)
 		req.URL.Path, req.URL.RawPath = savedPath, savedRaw
 		req.Host = u.Host
+		// We rewrite Host to the upstream above, so the upstream's
+		// same-origin WebSocket check would 403 a handshake whose Origin
+		// still names the proxy. Present the upstream origin instead — but
+		// only for WS upgrades, since non-WS CORS must keep the real Origin.
+		// (An upstream that allow-lists the proxy's own origin rather than
+		// its host would still reject; that config is uncommon.)
+		if isWebSocketUpgrade(req) && req.Header.Get("Origin") != "" {
+			req.Header.Set("Origin", upstreamOrigin)
+		}
 	}
 
 	return &proxyRoute{
@@ -61,6 +73,21 @@ func newProxyRoute(re config.RouteEntry) (*proxyRoute, error) {
 		upstream: re.Upstream,
 		handler:  rp,
 	}, nil
+}
+
+// isWebSocketUpgrade reports whether req is a WebSocket upgrade handshake.
+// The Connection header may be a comma-separated token list (e.g.
+// "keep-alive, Upgrade"), so we scan its tokens rather than compare whole.
+func isWebSocketUpgrade(req *http.Request) bool {
+	if !strings.EqualFold(req.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
+	for tok := range strings.SplitSeq(req.Header.Get("Connection"), ",") {
+		if strings.EqualFold(strings.TrimSpace(tok), "upgrade") {
+			return true
+		}
+	}
+	return false
 }
 
 // matches reports whether the given request path falls under this route.

--- a/internal/server/proxy_routes_test.go
+++ b/internal/server/proxy_routes_test.go
@@ -49,12 +49,12 @@ func TestProxyRouteMatches(t *testing.T) {
 		path string
 		want bool
 	}{
-		{"/patterns", true},      // bare match (no trailing slash)
-		{"/patterns/", true},     // exact pattern
-		{"/patterns/foo", true},  // sub-path
-		{"/patternsfoo", false},  // not a prefix-segment
-		{"/other", false},        // unrelated
-		{"/", false},             // root
+		{"/patterns", true},     // bare match (no trailing slash)
+		{"/patterns/", true},    // exact pattern
+		{"/patterns/foo", true}, // sub-path
+		{"/patternsfoo", false}, // not a prefix-segment
+		{"/other", false},       // unrelated
+		{"/", false},            // root
 	}
 	for _, c := range prefixCases {
 		if got := prefix.matches(c.path); got != c.want {
@@ -169,5 +169,110 @@ func TestProxyRoute_WebSocketIntegration(t *testing.T) {
 	}
 	if string(msg) != "echo:hi" {
 		t.Errorf("ws echo: got %q", msg)
+	}
+}
+
+// Regression for #257: a browser dials the proxy with Origin = the proxy's
+// own host. The proxy rewrites Host to the upstream, so an upstream using a
+// strict same-origin check (gorilla's default, mirrored here) would 403 the
+// handshake unless the proxy also rewrites Origin to the upstream origin.
+// Without the Origin rewrite in newProxyRoute's Director this dial fails;
+// with it the handshake echoes.
+func TestProxyRoute_WebSocketCrossOrigin(t *testing.T) {
+	// Strict same-origin upstream: Origin must equal scheme://Host. This is
+	// equivalent to gorilla's default checkOrigin and to livetemplate's
+	// createSecureOriginChecker (AllowedOrigins empty, prod mode).
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool {
+		return r.Header.Get("Origin") == "http://"+r.Host
+	}}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return // upgrader already wrote 403
+		}
+		defer conn.Close()
+		mt, msg, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		_ = conn.WriteMessage(mt, append([]byte("echo:"), msg...))
+	}))
+	defer upstream.Close()
+
+	pr, err := newProxyRoute(config.RouteEntry{Pattern: "/proxy/", Type: "proxy", Upstream: upstream.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/proxy/", pr.handler)
+	front := httptest.NewServer(mux)
+	defer front.Close()
+
+	// Dial with an explicit cross-origin Origin (the proxy's own host) —
+	// this is what a real browser sends.
+	wsURL := "ws" + strings.TrimPrefix(front.URL, "http") + "/proxy/ws"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"Origin": {front.URL}})
+	if err != nil {
+		status := "n/a"
+		if resp != nil {
+			status = resp.Status
+		}
+		t.Fatalf("ws dial via proxy with cross-origin Origin failed (upstream status %s): %v", status, err)
+	}
+	defer conn.Close()
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("hi")); err != nil {
+		t.Fatal(err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(msg) != "echo:hi" {
+		t.Errorf("ws echo: got %q", msg)
+	}
+}
+
+// Unit-level proof that the proxy rewrites Origin to the upstream origin only
+// for WebSocket upgrades — guards the gating logic. Drives the handler via
+// ServeHTTP against a recording upstream (which echoes the Origin it saw back
+// in a response header) so the assertion is race-free and doesn't couple to
+// the proxy's internal Director field.
+func TestProxyRoute_RewritesOriginOnlyForWS(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Saw-Origin", r.Header.Get("Origin"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	// httptest URLs carry no path, so upstream.URL is exactly the origin
+	// (scheme://host) the Director should rewrite Origin to.
+	wantUpstreamOrigin := upstream.URL
+
+	pr, err := newProxyRoute(config.RouteEntry{Pattern: "/proxy/", Type: "proxy", Upstream: upstream.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// WS upgrade: Origin rewritten to the upstream origin. (The upstream
+	// returns 200 rather than 101, so the proxy relays normally and we read
+	// the echoed header — we're asserting on the forwarded Origin, not on a
+	// completed upgrade, which the cross-origin test already covers.)
+	wsReq := httptest.NewRequest(http.MethodGet, "http://docs.example.com/proxy/ws", nil)
+	wsReq.Header.Set("Upgrade", "websocket")
+	wsReq.Header.Set("Connection", "keep-alive, Upgrade")
+	wsReq.Header.Set("Origin", "http://docs.example.com")
+	wsRec := httptest.NewRecorder()
+	pr.handler.ServeHTTP(wsRec, wsReq)
+	if got := wsRec.Header().Get("X-Saw-Origin"); got != wantUpstreamOrigin {
+		t.Errorf("WS upgrade: upstream saw Origin %q, want rewritten to %q", got, wantUpstreamOrigin)
+	}
+
+	// Plain HTTP with an Origin: left untouched (non-WS CORS unaffected).
+	httpReq := httptest.NewRequest(http.MethodPost, "http://docs.example.com/proxy/api", nil)
+	httpReq.Header.Set("Origin", "http://docs.example.com")
+	httpRec := httptest.NewRecorder()
+	pr.handler.ServeHTTP(httpRec, httpReq)
+	if got := httpRec.Header().Get("X-Saw-Origin"); got != "http://docs.example.com" {
+		t.Errorf("non-WS: upstream saw Origin %q, want left unchanged", got)
 	}
 }

--- a/internal/server/proxy_routes_test.go
+++ b/internal/server/proxy_routes_test.go
@@ -275,4 +275,15 @@ func TestProxyRoute_RewritesOriginOnlyForWS(t *testing.T) {
 	if got := httpRec.Header().Get("X-Saw-Origin"); got != "http://docs.example.com" {
 		t.Errorf("non-WS: upstream saw Origin %q, want left unchanged", got)
 	}
+
+	// WS upgrade with no Origin header (some dialers omit it on same-host
+	// connections): must not inject one — the != "" guard handles this.
+	noOriginReq := httptest.NewRequest(http.MethodGet, "http://docs.example.com/proxy/ws", nil)
+	noOriginReq.Header.Set("Upgrade", "websocket")
+	noOriginReq.Header.Set("Connection", "Upgrade")
+	noOriginRec := httptest.NewRecorder()
+	pr.handler.ServeHTTP(noOriginRec, noOriginReq)
+	if got := noOriginRec.Header().Get("X-Saw-Origin"); got != "" {
+		t.Errorf("no-Origin WS: upstream saw Origin %q, want empty", got)
+	}
 }

--- a/proxy_ws_e2e_test.go
+++ b/proxy_ws_e2e_test.go
@@ -44,8 +44,9 @@ func TestProxyRoute_WebSocketUpgradeE2E(t *testing.T) {
 	var tdLog syncBuffer
 	prevOut := log.Writer()
 	prevFlags := log.Flags()
+	prevPrefix := log.Prefix()
 	log.SetOutput(&tdLog)
-	t.Cleanup(func() { log.SetOutput(prevOut); log.SetFlags(prevFlags) })
+	t.Cleanup(func() { log.SetOutput(prevOut); log.SetFlags(prevFlags); log.SetPrefix(prevPrefix) })
 
 	// --- Upstream: strict same-origin WS check (gorilla default / livetemplate
 	// prod default). Serves an HTML page that opens a WS back to the same host,
@@ -215,13 +216,18 @@ func waitForStatus(sel, wantPrefix string, timeout time.Duration) chromedp.Actio
 		for time.Now().Before(deadline) {
 			var txt string
 			if err := chromedp.Text(sel, &txt, chromedp.ByID).Do(ctx); err == nil {
+				// WS_ERROR is a settled state — stop polling and let the
+				// assertions report it. Only a real timeout is an error.
 				if strings.HasPrefix(txt, wantPrefix) || strings.HasPrefix(txt, "WS_ERROR") {
 					return nil
 				}
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
-		return nil // let the assertions report the actual state
+		// Surface the timeout in the chromedp error (the caller t.Fatalf's
+		// with it after dumping diagnostics); otherwise the only signal
+		// would be a confusing "#status = connecting" assertion failure.
+		return fmt.Errorf("timed out after %v waiting for %q prefix on %s", timeout, wantPrefix, sel)
 	})
 }
 

--- a/proxy_ws_e2e_test.go
+++ b/proxy_ws_e2e_test.go
@@ -1,0 +1,245 @@
+//go:build !ci
+
+package tinkerdown_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+	"github.com/gorilla/websocket"
+)
+
+// TestProxyRoute_WebSocketUpgradeE2E is the real-browser regression for #257.
+//
+// It stands up a strict same-origin WebSocket upstream, fronts it with a
+// tinkerdown `routes: type: proxy` route, drives a real browser to the
+// proxied page, and asserts via CDP network events that the WS handshake
+// returns 101 (not 403) and that a frame actually flows. The acceptance
+// signal is deliberately the handshake status + frame delivery — NOT
+// liveTemplateClient.isReady(), which returns true under the silent HTTP
+// fallback that masked this bug in production.
+//
+// Per project convention this captures all four diagnostic channels:
+// (1) browser console logs, (2) server logs (both the upstream's view of
+// the forwarded request and tinkerdown's own log output), (3) WebSocket
+// handshake status + frames via CDP, (4) rendered HTML.
+func TestProxyRoute_WebSocketUpgradeE2E(t *testing.T) {
+	const wsMarker = "WS_PUSH_MARKER_257"
+
+	// --- Capture tinkerdown's package-level log output (server logs, hop 1).
+	// These E2E tests run serially (single Docker Chrome container, no
+	// t.Parallel), so a scoped global redirect is safe; restored on cleanup.
+	var tdLog syncBuffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&tdLog)
+	t.Cleanup(func() { log.SetOutput(prevOut); log.SetFlags(prevFlags) })
+
+	// --- Upstream: strict same-origin WS check (gorilla default / livetemplate
+	// prod default). Serves an HTML page that opens a WS back to the same host,
+	// and on the WS path upgrades + pushes one frame. Logs every request so the
+	// upstream's view of the forwarded Origin/Upgrade headers is visible (server
+	// logs, hop 2 — the decisive diagnostic for this bug).
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool {
+		return r.Header.Get("Origin") == "http://"+r.Host
+	}}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("[upstream] %s %s Host=%q Origin=%q Upgrade=%q", r.Method, r.URL.Path, r.Host, r.Header.Get("Origin"), r.Header.Get("Upgrade"))
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				t.Logf("[upstream] WS upgrade rejected: %v", err)
+				return // upgrader already wrote the 403
+			}
+			defer conn.Close()
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(wsMarker)); err != nil {
+				t.Logf("[upstream] WS write: %v", err)
+				return
+			}
+			conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			_, _, _ = conn.ReadMessage() // drain the client's "hi" / wait for close
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, `<!doctype html><html><body>
+<div id="status">connecting</div>
+<script>
+  var proto = location.protocol === 'https:' ? 'wss://' : 'ws://';
+  var ws = new WebSocket(proto + location.host + '/proxy/ws');
+  ws.onopen = function () { console.log('ws open'); ws.send('hi'); };
+  ws.onmessage = function (e) { document.getElementById('status').textContent = 'WS_FRAME:' + e.data; };
+  ws.onerror = function () { document.getElementById('status').textContent = 'WS_ERROR'; console.log('ws error'); };
+  ws.onclose = function (e) { console.log('ws close code=' + e.code); };
+</script>
+</body></html>`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	// --- tinkerdown fixture: a proxy route fronting the upstream.
+	tdDir := authorProxyFixture(t, upstream.URL)
+	_, tdURL := startTinkerdown(t, tdDir)
+
+	// --- Drive a real browser, capturing all four channels.
+	chromeCtx, cleanup := SetupDockerChrome(t, 60*time.Second)
+	t.Cleanup(cleanup)
+	ctx := chromeCtx.Context
+
+	var (
+		mu              sync.Mutex
+		consoleLogs     []string
+		handshakeStatus []int64
+		framesReceived  []string
+		frameErrors     []string
+	)
+	chromedp.ListenTarget(ctx, func(ev any) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch e := ev.(type) {
+		case *runtime.EventConsoleAPICalled:
+			for _, arg := range e.Args {
+				consoleLogs = append(consoleLogs, string(arg.Value))
+			}
+		case *network.EventWebSocketHandshakeResponseReceived:
+			if e.Response != nil {
+				handshakeStatus = append(handshakeStatus, e.Response.Status)
+			}
+		case *network.EventWebSocketFrameReceived:
+			if e.Response != nil {
+				framesReceived = append(framesReceived, e.Response.PayloadData)
+			}
+		case *network.EventWebSocketFrameError:
+			frameErrors = append(frameErrors, e.ErrorMessage)
+		}
+	})
+
+	url := ConvertURLForDockerChrome(tdURL)
+	t.Logf("Test server URL: %s (Docker: %s)", tdURL, url)
+
+	var status, htmlContent string
+	runErr := chromedp.Run(ctx,
+		network.Enable(),
+		chromedp.Navigate(url+"/proxy/page"),
+		// Wait for the WS frame to land and update the DOM.
+		chromedp.WaitVisible(`#status`, chromedp.ByID),
+		waitForStatus(`#status`, "WS_FRAME:", 5*time.Second),
+		chromedp.Text(`#status`, &status, chromedp.ByID),
+		chromedp.OuterHTML("html", &htmlContent),
+	)
+
+	// Hold the lock across the diagnostic dump and the assertions below —
+	// the CDP listener goroutine may still append events (e.g. ws close).
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Dump all four diagnostic channels unconditionally — cheap, and
+	// invaluable on any failure below.
+	t.Logf("[console] %v", consoleLogs)
+	t.Logf("[handshake statuses] %v", handshakeStatus)
+	t.Logf("[frames] %v", framesReceived)
+	t.Logf("[frame errors] %v", frameErrors)
+	t.Logf("[tinkerdown log]\n%s", tdLog.String())
+	t.Logf("[html] %s", firstChars(htmlContent, 2000))
+	if runErr != nil {
+		t.Fatalf("chromedp.Run: %v", runErr)
+	}
+
+	// (1) No 403, and a 101 Switching Protocols was observed.
+	saw101 := false
+	for _, s := range handshakeStatus {
+		if s == 403 {
+			t.Errorf("WS handshake returned 403 — proxy did not rewrite Origin (the #257 bug)")
+		}
+		if s == 101 {
+			saw101 = true
+		}
+	}
+	if !saw101 {
+		t.Errorf("expected a 101 Switching Protocols handshake, got statuses %v", handshakeStatus)
+	}
+
+	// (2) A WS frame carrying the upstream marker actually flowed.
+	frameSeen := false
+	for _, f := range framesReceived {
+		if strings.Contains(f, wsMarker) {
+			frameSeen = true
+		}
+	}
+	if !frameSeen {
+		t.Errorf("expected a WS frame containing %q, got frames %v", wsMarker, framesReceived)
+	}
+
+	// (3) Rendered HTML reflects the pushed frame (not the HTTP fallback).
+	if !strings.Contains(status, wsMarker) {
+		t.Errorf("#status = %q, want it to contain the pushed marker %q", status, wsMarker)
+	}
+}
+
+// authorProxyFixture writes a tinkerdown site with a `routes: type: proxy`
+// route at /proxy/ pointing at the given upstream, plus a home page so
+// Discover succeeds. Returns the temp dir tinkerdown should serve from.
+func authorProxyFixture(t *testing.T, upstreamURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := "title: \"Proxy WS E2E\"\n" +
+		"routes:\n" +
+		"  - pattern: \"/proxy/\"\n" +
+		"    type: proxy\n" +
+		"    upstream: \"" + upstreamURL + "\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "tinkerdown.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\ntitle: \"Home\"\n---\n\n# Home\n"
+	if err := os.WriteFile(filepath.Join(dir, "index.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// waitForStatus polls an element's textContent until it has the wanted
+// prefix or the timeout elapses. Avoids a fixed Sleep race on the WS frame.
+func waitForStatus(sel, wantPrefix string, timeout time.Duration) chromedp.Action {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			var txt string
+			if err := chromedp.Text(sel, &txt, chromedp.ByID).Do(ctx); err == nil {
+				if strings.HasPrefix(txt, wantPrefix) || strings.HasPrefix(txt, "WS_ERROR") {
+					return nil
+				}
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		return nil // let the assertions report the actual state
+	})
+}
+
+// syncBuffer is a goroutine-safe bytes buffer for capturing log output that
+// the http server writes from its handler goroutines.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/proxy_ws_e2e_test.go
+++ b/proxy_ws_e2e_test.go
@@ -195,11 +195,9 @@ func TestProxyRoute_WebSocketUpgradeE2E(t *testing.T) {
 func authorProxyFixture(t *testing.T, upstreamURL string) string {
 	t.Helper()
 	dir := t.TempDir()
-	cfg := "title: \"Proxy WS E2E\"\n" +
-		"routes:\n" +
-		"  - pattern: \"/proxy/\"\n" +
-		"    type: proxy\n" +
-		"    upstream: \"" + upstreamURL + "\"\n"
+	// %q quotes the upstream URL so the helper stays safe if a future test
+	// reuses it with a URL containing YAML-significant characters.
+	cfg := fmt.Sprintf("title: \"Proxy WS E2E\"\nroutes:\n  - pattern: \"/proxy/\"\n    type: proxy\n    upstream: %q\n", upstreamURL)
 	if err := os.WriteFile(filepath.Join(dir, "tinkerdown.yaml"), []byte(cfg), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/proxy_ws_e2e_test.go
+++ b/proxy_ws_e2e_test.go
@@ -212,8 +212,11 @@ func authorProxyFixture(t *testing.T, upstreamURL string) string {
 // prefix or the timeout elapses. Avoids a fixed Sleep race on the WS frame.
 func waitForStatus(sel, wantPrefix string, timeout time.Duration) chromedp.Action {
 	return chromedp.ActionFunc(func(ctx context.Context) error {
-		deadline := time.Now().Add(timeout)
-		for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
 			var txt string
 			if err := chromedp.Text(sel, &txt, chromedp.ByID).Do(ctx); err == nil {
 				// WS_ERROR is a settled state — stop polling and let the
@@ -222,12 +225,16 @@ func waitForStatus(sel, wantPrefix string, timeout time.Duration) chromedp.Actio
 					return nil
 				}
 			}
-			time.Sleep(100 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				// Surface the timeout/cancellation in the chromedp error (the
+				// caller t.Fatalf's with it after dumping diagnostics);
+				// otherwise the only signal would be a confusing
+				// "#status = connecting" assertion failure.
+				return fmt.Errorf("gave up after %v waiting for %q prefix on %s: %w", timeout, wantPrefix, sel, ctx.Err())
+			case <-ticker.C:
+			}
 		}
-		// Surface the timeout in the chromedp error (the caller t.Fatalf's
-		// with it after dumping diagnostics); otherwise the only signal
-		// would be a confusing "#status = connecting" assertion failure.
-		return fmt.Errorf("timed out after %v waiting for %q prefix on %s", timeout, wantPrefix, sel)
 	})
 }
 

--- a/proxy_ws_e2e_test.go
+++ b/proxy_ws_e2e_test.go
@@ -39,8 +39,10 @@ func TestProxyRoute_WebSocketUpgradeE2E(t *testing.T) {
 	const wsMarker = "WS_PUSH_MARKER_257"
 
 	// --- Capture tinkerdown's package-level log output (server logs, hop 1).
-	// These E2E tests run serially (single Docker Chrome container, no
-	// t.Parallel), so a scoped global redirect is safe; restored on cleanup.
+	// This mutates the process-global logger, so it is only safe while this
+	// test runs serially. SERIAL — never add t.Parallel() to this test (or
+	// run it with a parallel sibling that also redirects log output); the
+	// global redirect would race. Restored on cleanup.
 	var tdLog syncBuffer
 	prevOut := log.Writer()
 	prevFlags := log.Flags()


### PR DESCRIPTION
## Summary

Fixes #257. `routes: type: proxy` loaded HTML fine but every WebSocket upgrade returned **403**, so the embedded LiveTemplate client silently fell back to HTTP polling — invisible because `isReady()` stays `true` under fallback.

**Root cause (confirmed from primary source, not inferred):** the issue title ("doesn't forward WebSocket upgrades") misdiagnoses it. Go's stdlib `httputil.ReverseProxy` forwards WS upgrades natively (Go 1.12+; repo is on 1.26). The real bug: the Director rewrites `req.Host` to the upstream but left the `Origin` header pointing at the proxy's domain. The upstream (a LiveTemplate app) runs `createSecureOriginChecker`, whose production default requires `Origin == scheme://Host` — so the handshake mismatched and gorilla/websocket returned 403.

## Fix

Rewrite the `Origin` header to the upstream origin inside the proxy Director, **gated on the WebSocket upgrade headers** (new `isWebSocketUpgrade` helper) so non-WS CORS behavior is untouched. This is the standard reverse-proxy pattern (nginx `proxy_set_header Origin`). One change point in `newProxyRoute` covers both config-declared `routes: type: proxy` and `embed-lvt` auto-routes.

## Tests (each proven to fail without the fix, pass with it)

- **`TestProxyRoute_WebSocketCrossOrigin`** — Go integration reproducing the cross-origin **403** against a strict same-origin upstream.
- **`TestProxyRoute_RewritesOriginOnlyForWS`** — asserts Origin is rewritten for WS, left unchanged for plain HTTP.
- **`TestProxyRoute_WebSocketUpgradeE2E`** — chromedp E2E asserting a **101 handshake + WS frame via CDP** (deliberately *not* `isReady()`, which masks the bug), capturing all four diagnostic channels: console logs, server logs, WS frames, rendered HTML.

## Verification

- CI gate locally: `go build ./...` clean; `go test -race -tags=ci -skip='E2E|e2e' ./...` → all packages pass.
- New E2E + related embed-lvt E2E pass under Docker Chrome.
- gofmt/vet clean; introduces no new lint findings.

## Scope

Tight per triage. The new WS-origin E2E partially addresses #143. #144 (configurable CSP) is the inverse scenario (tinkerdown's own `/ws` behind a proxy) and stays separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)