### PR TITLE
M1 Phase 3: attribute validation + the generation workflow

### DIFF
--- a/attribute_docs_test.go
+++ b/attribute_docs_test.go
@@ -229,7 +229,16 @@ func collectGo(t *testing.T, dir string, out *[]byte) {
 		// attribute exists: a fixture using a made-up attribute would vouch for the
 		// docs that invented it — and this very file names lvt-filter in its comments,
 		// which silently defeated the check until _test.go was excluded.
-		case strings.HasSuffix(e.Name(), ".go") && !strings.HasSuffix(e.Name(), "_test.go"):
+		//
+		// vocabulary.go is excluded for the same reason in production form: its
+		// migration table names dead attributes precisely in order to suggest
+		// replacements ("lvt-animate" -> "lvt-fx:animate"), and a substring scan
+		// cannot tell mentioning an attribute from implementing one. That exclusion
+		// would be a blind spot on its own, so TestMigrationHintsAgreeWithRemovedLists
+		// covers the same ground by a different route.
+		case strings.HasSuffix(e.Name(), ".go") &&
+			!strings.HasSuffix(e.Name(), "_test.go") &&
+			e.Name() != "vocabulary.go":
 			b, err := os.ReadFile(path)
 			if err != nil {
 				continue
@@ -370,4 +379,42 @@ func TestRemovedAttributesAreReallyGone(t *testing.T) {
 
 	check(documentedAsRemoved, "superseded/removed")
 	check(neverImplemented, "never implemented")
+}
+
+// TestMigrationHintsAgreeWithRemovedLists keeps vocabulary.go's migration table and
+// this file's removed/never-implemented lists from drifting apart.
+//
+// vocabulary.go is excluded from the Go scan above, because naming a dead attribute in
+// order to suggest its replacement is indistinguishable, to a substring search, from
+// implementing it. That exclusion would be a blind spot on its own — so rather than
+// trusting the file, this asserts the two agree: every attribute vocabulary.go offers a
+// migration away from must be one this file also records as dead, and must genuinely be
+// absent from the shipped client.
+//
+// Revive an attribute and both must be updated; add a migration hint for something
+// still live and this fails.
+func TestMigrationHintsAgreeWithRemovedLists(t *testing.T) {
+	migrated := []string{
+		"lvt-scroll", "lvt-highlight", "lvt-animate", "lvt-throttle",
+		"lvt-disable-with", "lvt-preserve", "lvt-click-away",
+		"lvt-modal-open", "lvt-modal-close", "lvt-filter",
+	}
+
+	for _, name := range migrated {
+		if !documentedAsRemoved[name] && !neverImplemented[name] {
+			t.Errorf("vocabulary.go offers a migration for %q, but neither documentedAsRemoved "+
+				"nor neverImplemented records it as dead — one of the two is wrong", name)
+		}
+	}
+
+	bundle, err := os.ReadFile("internal/assets/client/tinkerdown-client.browser.js")
+	if err != nil {
+		t.Fatalf("read client bundle: %v", err)
+	}
+	for _, name := range migrated {
+		if implemented(name, bundle) {
+			t.Errorf("vocabulary.go tells users to migrate away from %q, but it IS implemented "+
+				"in the shipped client — the hint would send them away from working code", name)
+		}
+	}
 }

--- a/cmd/tinkerdown/commands/validate.go
+++ b/cmd/tinkerdown/commands/validate.go
@@ -127,7 +127,9 @@ func ValidateCommand(args []string) error {
 			// binds to nothing, and reports no error anywhere — the hardest of the
 			// three "validates clean but does nothing" cases to notice, because
 			// every available signal says success.
-			if inert := page.InertAttributes(); len(inert) > 0 {
+			inert := page.InertAttributes()
+			unknown := page.UnknownAttributes()
+			if len(inert) > 0 {
 				fileErrors = append(fileErrors, fileValidationError{
 					file: relPath,
 					error: fmt.Sprintf("%s used outside an ```lvt block — this markup renders but nothing binds to it; move it inside a ```lvt fence",
@@ -140,10 +142,10 @@ func ValidateCommand(args []string) error {
 			// proves the document parses, and an unknown attribute is emitted as
 			// inert HTML — so a generated page could satisfy "validate is clean"
 			// while doing nothing.
-			for _, unknown := range page.UnknownAttributes() {
-				msg := fmt.Sprintf("unknown attribute %q", unknown.Name)
-				if unknown.Hint != "" {
-					msg += " (" + unknown.Hint + ")"
+			for _, u := range unknown {
+				msg := fmt.Sprintf("unknown attribute %q", u.Name)
+				if u.Hint != "" {
+					msg += " (" + u.Hint + ")"
 				}
 				fileErrors = append(fileErrors, fileValidationError{file: relPath, error: msg})
 				totalErrors++
@@ -174,7 +176,7 @@ func ValidateCommand(args []string) error {
 					error: fmt.Sprintf("Mermaid errors:\n  %s", errorMsg),
 				})
 				totalErrors += len(mermaidErrors)
-			} else if len(violations) == 0 && len(page.UnknownAttributes()) == 0 && len(page.InertAttributes()) == 0 {
+			} else if len(violations) == 0 && len(unknown) == 0 && len(inert) == 0 {
 				validFiles++
 				fmt.Printf("✓ %s\n", relPath)
 			}

--- a/cmd/tinkerdown/commands/validate.go
+++ b/cmd/tinkerdown/commands/validate.go
@@ -123,6 +123,19 @@ func ValidateCommand(args []string) error {
 			})
 			totalErrors++
 		} else {
+			// Vocabulary: does every lvt-* attribute exist? validate otherwise only
+			// proves the document parses, and an unknown attribute is emitted as
+			// inert HTML — so a generated page could satisfy "validate is clean"
+			// while doing nothing.
+			for _, unknown := range page.UnknownAttributes() {
+				msg := fmt.Sprintf("unknown attribute %q", unknown.Name)
+				if unknown.Hint != "" {
+					msg += " (" + unknown.Hint + ")"
+				}
+				fileErrors = append(fileErrors, fileValidationError{file: relPath, error: msg})
+				totalErrors++
+			}
+
 			// Policy: does this document stay inside the project's approved surface?
 			violations := manifest.CheckPolicy(pageRefs(page))
 			for _, v := range violations {
@@ -148,7 +161,7 @@ func ValidateCommand(args []string) error {
 					error: fmt.Sprintf("Mermaid errors:\n  %s", errorMsg),
 				})
 				totalErrors += len(mermaidErrors)
-			} else if len(violations) == 0 {
+			} else if len(violations) == 0 && len(page.UnknownAttributes()) == 0 {
 				validFiles++
 				fmt.Printf("✓ %s\n", relPath)
 			}

--- a/cmd/tinkerdown/commands/validate.go
+++ b/cmd/tinkerdown/commands/validate.go
@@ -123,6 +123,19 @@ func ValidateCommand(args []string) error {
 			})
 			totalErrors++
 		} else {
+			// Placement: lvt-* markup outside an ```lvt block is inert. It renders,
+			// binds to nothing, and reports no error anywhere — the hardest of the
+			// three "validates clean but does nothing" cases to notice, because
+			// every available signal says success.
+			if inert := page.InertAttributes(); len(inert) > 0 {
+				fileErrors = append(fileErrors, fileValidationError{
+					file: relPath,
+					error: fmt.Sprintf("%s used outside an ```lvt block — this markup renders but nothing binds to it; move it inside a ```lvt fence",
+						strings.Join(inert, ", ")),
+				})
+				totalErrors++
+			}
+
 			// Vocabulary: does every lvt-* attribute exist? validate otherwise only
 			// proves the document parses, and an unknown attribute is emitted as
 			// inert HTML — so a generated page could satisfy "validate is clean"
@@ -161,7 +174,7 @@ func ValidateCommand(args []string) error {
 					error: fmt.Sprintf("Mermaid errors:\n  %s", errorMsg),
 				})
 				totalErrors += len(mermaidErrors)
-			} else if len(violations) == 0 && len(page.UnknownAttributes()) == 0 {
+			} else if len(violations) == 0 && len(page.UnknownAttributes()) == 0 && len(page.InertAttributes()) == 0 {
 				validFiles++
 				fmt.Printf("✓ %s\n", relPath)
 			}

--- a/skills/tinkerdown/SKILL.md
+++ b/skills/tinkerdown/SKILL.md
@@ -36,15 +36,106 @@ Use Tinkerdown for:
 - Apps requiring complex client-side state (use React/Vue)
 - Real-time multiplayer games
 
-## Generate, then validate
+## The generation workflow
 
 Interactivity comes from a **fixed vocabulary**, not freeform HTML — that constraint is
 what makes generated output reliable. Stay inside it (see `reference.md`) rather than
 reaching for custom JavaScript.
 
-Always run `tinkerdown validate <file>` on generated markdown before serving it. It
-parses with the real parser and reports errors with file, line, and a hint, so you can
-self-correct to a clean pass instead of discovering breakage in the browser.
+Follow these steps in order. They exist because each one catches something the next
+cannot.
+
+### 1. Read the approved surface, if there is one
+
+If the project has a `tinkerdown.yaml` with a `generation:` block, it declares the
+sources and actions you may use — and those are the **only** ones you may use:
+
+```bash
+cat tinkerdown.yaml
+```
+
+Each approved source and action may carry a `describes:` note saying what it touches.
+Use those names as given. **Do not declare your own `sources:` or `actions:` in the
+document's frontmatter** — a name outside the approved set fails validation, and
+redefining an approved name silently has no effect, because approved definitions are
+pinned and yours will be ignored.
+
+No `generation:` block means no approved surface: declare sources in frontmatter as
+normal.
+
+### 2. Write the document
+
+**Put `lvt-*` markup inside a ```lvt fence.** Outside one it is ordinary HTML: the page
+renders, nothing binds, and no error appears anywhere — not in the browser console, not
+in the server log. It simply sits there looking correct. This is the easiest mistake to
+make and the hardest to spot.
+
+````markdown
+```lvt
+<table lvt-source="requests" lvt-columns="id,requester,status"></table>
+<button name="approve" data-id="1">Approve</button>
+```
+````
+
+Use only attributes from `reference.md`. If you need a capability you cannot find
+there, check whether it exists before inventing an attribute for it — a plausible
+invention is the most common way generated pages fail.
+
+### 3. Validate, and fix what it reports
+
+```bash
+tinkerdown validate app.md
+```
+
+This is the gate, and it now checks three separate things:
+
+- **Syntax** — the document parses.
+- **Vocabulary** — every `lvt-*` attribute is one something actually implements.
+  `unknown attribute "lvt-sortable"` means you invented it; a hint names the
+  replacement when there is one.
+- **Policy** — every source and action is in the approved set, whether referenced or
+  declared.
+- **Placement** — no `lvt-*` markup sits outside a ```lvt fence, where it would be
+  inert.
+
+Fix and re-run until it passes. Each diagnostic carries a hint naming the approved
+alternatives or the correct attribute, so work from those rather than guessing.
+
+**Stop after about five rounds.** If it is still failing, the request likely needs a
+capability the vocabulary does not have. Say so rather than continuing to substitute
+attributes — a page that validates but does the wrong thing is worse than an honest
+"this needs something Tinkerdown does not do."
+
+### 4. Check what the app does, if it is privileged
+
+```bash
+tinkerdown validate --summary app-directory
+```
+
+Emits JSON on stdout. When `"privileged": true`, the app executes commands, writes
+data, or reaches the network — **show the operator the `operations` list and get their
+OK before serving.** Each entry carries the manifest's `describes:` note, which is what
+makes the list reviewable.
+
+When `privileged` is false the app only reads. Serve it without interrupting anyone; a
+prompt on every generated page is a prompt nobody reads.
+
+This command fails if the project config cannot be read. That is deliberate — a policy
+gate that cannot see the policy must not report "nothing to review."
+
+### 5. Serve it
+
+```bash
+tinkerdown serve <directory>
+```
+
+Write the document to a scratch directory and serve that. Ephemeral means nothing is
+persisted and the directory is deleted afterwards — not that nothing touches disk. A
+directory the operator can re-run and inspect is more useful than one they cannot, and
+if the UI turns out to be worth keeping, it already is a file.
+
+Exec sources and actions additionally require `--allow-exec`; that decision belongs to
+whoever runs the server, not to the document.
 
 ## Quick Start
 

--- a/vocabulary.go
+++ b/vocabulary.go
@@ -63,7 +63,35 @@ var knownPrefixes = []string{
 	"lvt-mod:",
 	"lvt-form:",
 	"lvt-nav:",
-	"data-lvt-", // data-lvt-force-update, data-lvt-target, and friends
+}
+
+// knownDataAttributes is the data-lvt-* set. Unlike the namespaces above it is closed
+// and enumerable, so it is checked exactly rather than by prefix. Allowing the whole
+// prefix would have let data-lvt-sortable validate clean — the same hole this file
+// exists to close, one namespace over.
+var knownDataAttributes = map[string]bool{
+	"data-lvt-force-update":        true,
+	"data-lvt-target":              true,
+	"data-lvt-id":                  true,
+	"data-lvt-id-pending":          true,
+	"data-lvt-key":                 true,
+	"data-lvt-redact":              true,
+	"data-lvt-autofocused":         true,
+	"data-lvt-heartbeat-ms":        true,
+	"data-lvt-iv-done":             true,
+	"data-lvt-loading":             true,
+	"data-lvt-loading-debounce-ms": true,
+	"data-lvt-scroll-sticky":       true,
+	"data-lvt-targeted-applied":    true,
+	"data-lvt-targeted-skip":       true,
+	"data-lvt-text-caret":          true,
+	"data-lvt-text-select-button":  true,
+	"data-lvt-toast-content":       true,
+	"data-lvt-toast-item":          true,
+	"data-lvt-toast-stack":         true,
+	"data-lvt-upload-preview":      true,
+	"data-lvt-url-hash":            true,
+	"data-lvt-viewport-items":      true,
 }
 
 // UnknownAttribute is an lvt-* attribute a document uses that nothing implements.
@@ -97,7 +125,7 @@ func (p *Page) UnknownAttributes() []UnknownAttribute {
 					if !strings.HasPrefix(attr.Key, "lvt-") && !strings.HasPrefix(attr.Key, "data-lvt-") {
 						continue
 					}
-					if knownAttributes[attr.Key] || hasKnownPrefix(attr.Key) {
+					if knownAttributes[attr.Key] || knownDataAttributes[attr.Key] || hasKnownPrefix(attr.Key) {
 						continue
 					}
 					found[attr.Key] = true

--- a/vocabulary.go
+++ b/vocabulary.go
@@ -1,0 +1,170 @@
+package tinkerdown
+
+import (
+	"sort"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// knownAttributes is the set of exact-match lvt-* attribute names something implements
+// — either Tinkerdown itself or the client bundle it ships.
+//
+// This exists because `tinkerdown validate` checks that a document *parses*, not that
+// its attributes are real: an unknown lvt-* attribute is emitted as inert HTML and does
+// nothing, silently. That is tolerable for a hand-written page whose author notices it
+// did not work. It is not tolerable for a generated one, where the loop is "self-correct
+// until validate is clean" — clean would otherwise mean nothing about whether the page
+// functions, and a hallucinated attribute would survive every iteration.
+//
+// The list is deliberately hand-maintained rather than derived at runtime, so validate
+// stays fast and dependency-free. TestKnownAttributesAreReal keeps it honest by checking
+// every entry against the vendored client bundle and Tinkerdown's own source — the same
+// two-directional guard the attribute reference uses. An entry that stops being real
+// fails the build.
+var knownAttributes = map[string]bool{
+	// Tinkerdown-owned: data binding and auto-rendering.
+	"lvt-source":    true,
+	"lvt-columns":   true,
+	"lvt-field":     true,
+	"lvt-value":     true,
+	"lvt-label":     true,
+	"lvt-empty":     true,
+	"lvt-actions":   true,
+	"lvt-datatable": true,
+	"lvt-persist":   true,
+
+	// Client-owned: events, effects, forms, lifecycle, DOM guards.
+	"lvt-key":          true,
+	"lvt-autofocus":    true,
+	"lvt-focus-trap":   true,
+	"lvt-ignore":       true,
+	"lvt-ignore-attrs": true,
+	"lvt-debounce":     true,
+	"lvt-upload":       true,
+	"lvt-spy":          true,
+	"lvt-redact":       true,
+	"lvt-scroll-away":  true,
+}
+
+// knownPrefixes are namespaces whose members are dispatched at runtime rather than
+// enumerated. `lvt-on:` takes arbitrary DOM event names; `lvt-el:` takes a method and a
+// lifecycle state; `lvt-fx:`, `lvt-mod:`, `lvt-form:` and `lvt-nav:` take a behavior.
+//
+// Validating only the namespace is a deliberate limit, not an oversight: there is no
+// enumerable member set for lvt-on:, and hard-coding one for the others would create a
+// second list to rot. A typo in a *member* (lvt-el:bogus:on:success) still passes. A
+// typo in the namespace, or an invented attribute entirely, does not — and that is the
+// larger share of what a generating model gets wrong.
+var knownPrefixes = []string{
+	"lvt-on:",
+	"lvt-el:",
+	"lvt-fx:",
+	"lvt-mod:",
+	"lvt-form:",
+	"lvt-nav:",
+	"data-lvt-", // data-lvt-force-update, data-lvt-target, and friends
+}
+
+// UnknownAttribute is an lvt-* attribute a document uses that nothing implements.
+type UnknownAttribute struct {
+	Name string
+	Hint string
+}
+
+// UnknownAttributes reports lvt-* attributes the page uses that nothing implements.
+//
+// Returned in a stable order so a generating agent sees the same diagnostics on every
+// run and can converge, rather than chasing a different subset each iteration.
+func (p *Page) UnknownAttributes() []UnknownAttribute {
+	if p == nil {
+		return nil
+	}
+
+	found := map[string]bool{}
+	scan := func(markup string) {
+		if strings.TrimSpace(markup) == "" {
+			return
+		}
+		doc, err := html.Parse(strings.NewReader(markup))
+		if err != nil {
+			return
+		}
+		var walk func(*html.Node)
+		walk = func(n *html.Node) {
+			if n.Type == html.ElementNode {
+				for _, attr := range n.Attr {
+					if !strings.HasPrefix(attr.Key, "lvt-") && !strings.HasPrefix(attr.Key, "data-lvt-") {
+						continue
+					}
+					if knownAttributes[attr.Key] || hasKnownPrefix(attr.Key) {
+						continue
+					}
+					found[attr.Key] = true
+				}
+			}
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				walk(c)
+			}
+		}
+		walk(doc)
+	}
+
+	for _, block := range p.ServerBlocks {
+		if block != nil {
+			scan(block.Content)
+		}
+	}
+	for _, block := range p.InteractiveBlocks {
+		if block != nil {
+			scan(block.Content)
+		}
+	}
+	scan(p.StaticHTML)
+
+	names := make([]string, 0, len(found))
+	for name := range found {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := make([]UnknownAttribute, 0, len(names))
+	for _, name := range names {
+		out = append(out, UnknownAttribute{Name: name, Hint: suggestAttribute(name)})
+	}
+	return out
+}
+
+func hasKnownPrefix(name string) bool {
+	for _, prefix := range knownPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// suggestAttribute points at the right name when the wrong one is a known migration.
+// A bare guess would be worse than none — a wrong suggestion sends a self-correcting
+// agent somewhere specific and wrong, which is harder to recover from than "unknown".
+func suggestAttribute(name string) string {
+	migrations := map[string]string{
+		"lvt-scroll":       "lvt-fx:scroll",
+		"lvt-highlight":    "lvt-fx:highlight",
+		"lvt-animate":      "lvt-fx:animate",
+		"lvt-throttle":     "lvt-mod:throttle",
+		"lvt-disable-with": "lvt-form:disable-with",
+		"lvt-preserve":     "lvt-ignore (or lvt-form:preserve for form values)",
+		"lvt-click-away":   "an lvt-el: lifecycle state, e.g. lvt-el:removeClass:on:click-away",
+		"lvt-modal-open":   "a native <dialog> element",
+		"lvt-modal-close":  "a native <dialog> element",
+		"lvt-filter":       "filter at the source instead (a SQL query, or a computed source)",
+	}
+	if to, ok := migrations[name]; ok {
+		return "use " + to
+	}
+	if strings.HasPrefix(name, "lvt-value-") {
+		return "lvt-value-* is not implemented; pass extra values as data-* attributes or a form field"
+	}
+	return ""
+}

--- a/vocabulary.go
+++ b/vocabulary.go
@@ -120,6 +120,9 @@ func (p *Page) UnknownAttributes() []UnknownAttribute {
 			scan(block.Content)
 		}
 	}
+	// Static HTML is markup outside any lvt block. Attributes there are inert: the
+	// page renders, nothing binds, and no error is raised anywhere — see
+	// InertAttributes, which reports that separately.
 	scan(p.StaticHTML)
 
 	names := make([]string, 0, len(found))
@@ -167,4 +170,52 @@ func suggestAttribute(name string) string {
 		return "lvt-value-* is not implemented; pass extra values as data-* attributes or a form field"
 	}
 	return ""
+}
+
+// InertAttributes reports lvt-* attributes that sit outside any ```lvt block.
+//
+// Such markup is real HTML and renders fine, but nothing binds to it: no source is
+// read, no action fires, and no error appears in the server log or the browser console.
+// The page simply sits there looking correct.
+//
+// This is the third distinct way a document can pass validation and still not work —
+// after unknown attributes and unapproved names — and the hardest to notice, because
+// every signal available says success. It is easy to produce: putting a table in the
+// markdown body rather than in a fence is the natural thing to write.
+func (p *Page) InertAttributes() []string {
+	if p == nil || strings.TrimSpace(p.StaticHTML) == "" {
+		return nil
+	}
+	doc, err := html.Parse(strings.NewReader(p.StaticHTML))
+	if err != nil {
+		return nil
+	}
+
+	found := map[string]bool{}
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			for _, attr := range n.Attr {
+				// data-lvt-* are client-side hints that are meaningful on ordinary
+				// markup; only the binding vocabulary is inert out here.
+				if strings.HasPrefix(attr.Key, "lvt-") {
+					found[attr.Key] = true
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	if len(found) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(found))
+	for name := range found {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/vocabulary_test.go
+++ b/vocabulary_test.go
@@ -23,8 +23,11 @@ func TestKnownAttributesAreReal(t *testing.T) {
 	}
 	goSrc := readProductionGo(t)
 
-	names := make([]string, 0, len(knownAttributes))
+	names := make([]string, 0, len(knownAttributes)+len(knownDataAttributes))
 	for name := range knownAttributes {
+		names = append(names, name)
+	}
+	for name := range knownDataAttributes {
 		names = append(names, name)
 	}
 	sort.Strings(names)
@@ -66,7 +69,15 @@ func TestUnknownAttributes(t *testing.T) {
 		{name: "a real attribute passes", markup: `<table lvt-source="x" lvt-columns="a"></table>`},
 		{name: "a namespaced member passes", markup: `<form lvt-el:reset:on:success></form>`},
 		{name: "an arbitrary lvt-on event passes", markup: `<div lvt-on:mouseenter="Hover"></div>`},
-		{name: "data-lvt-* passes", markup: `<input data-lvt-force-update>`},
+		{name: "a real data-lvt-* passes", markup: `<input data-lvt-force-update>`},
+		{
+			// data-lvt-* is a closed set, so an invented one must be caught like any
+			// other. Allowing the bare prefix would have let this through — the same
+			// hole this file exists to close, one namespace over.
+			name:     "an invented data-lvt-* is reported",
+			markup:   `<table data-lvt-sortable></table>`,
+			wantName: "data-lvt-sortable",
+		},
 		{name: "plain HTML is untouched", markup: `<div class="x" data-id="1"><input name="q"></div>`},
 	}
 
@@ -110,7 +121,15 @@ func readProductionGo(t *testing.T) []byte {
 					continue
 				}
 				walk(path)
-			case strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go"):
+			// vocabulary.go must be excluded, for the same reason collectGo excludes
+			// it in attribute_docs_test.go: a substring scan cannot tell mentioning an
+			// attribute from implementing one. Without this the guard is circular —
+			// knownAttributes' own map keys live in this file, so every entry matches
+			// itself and the test can never fail. Adding "lvt-totally-made-up" to the
+			// allowlist passed cleanly until this line existed.
+			case strings.HasSuffix(name, ".go") &&
+				!strings.HasSuffix(name, "_test.go") &&
+				name != "vocabulary.go":
 				if b, err := os.ReadFile(path); err == nil {
 					all = append(all, b...)
 				}

--- a/vocabulary_test.go
+++ b/vocabulary_test.go
@@ -146,3 +146,62 @@ func isNameChar(r rune) bool {
 	return r == '-' || r == ':' || r == '_' ||
 		(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
 }
+
+// TestInertAttributes covers the failure I produced by following this project's own
+// skill instructions: a table in the markdown body rather than in an ```lvt fence.
+//
+// It validated clean, summarised as privileged, served without error, and rendered
+// nothing — no source read, no console error, no server-log warning. Every available
+// signal said success. That makes it the hardest of the three "clean but broken" cases
+// to notice, and the easiest to write, since putting markup in the body is the natural
+// thing to do.
+func TestInertAttributes(t *testing.T) {
+	tests := []struct {
+		name   string
+		static string
+		want   []string
+	}{
+		{
+			name:   "binding markup in the body is inert",
+			static: `<table lvt-source="requests" lvt-columns="id"></table>`,
+			want:   []string{"lvt-columns", "lvt-source"},
+		},
+		{
+			name:   "an action binding in the body is inert",
+			static: `<div lvt-on:click="Approve"></div>`,
+			want:   []string{"lvt-on:click"},
+		},
+		{
+			// data-lvt-* are client-side hints that mean something on ordinary
+			// markup, so they are not inert out here.
+			name:   "data-lvt-* is meaningful outside a block",
+			static: `<input data-lvt-force-update>`,
+		},
+		{name: "plain HTML is untouched", static: `<div class="x"><input name="q"></div>`},
+		{name: "empty static HTML", static: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := (&Page{StaticHTML: tc.static}).InertAttributes()
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %v, want %v", got, tc.want)
+					break
+				}
+			}
+		})
+	}
+
+	t.Run("markup inside a block is not inert", func(t *testing.T) {
+		page := &Page{ServerBlocks: map[string]*ServerBlock{
+			"b": {Content: `<table lvt-source="requests"></table>`},
+		}}
+		if got := page.InertAttributes(); len(got) != 0 {
+			t.Errorf("attributes inside an lvt block bind correctly; got %v", got)
+		}
+	})
+}

--- a/vocabulary_test.go
+++ b/vocabulary_test.go
@@ -1,0 +1,148 @@
+package tinkerdown
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestKnownAttributesAreReal keeps the allowlist honest.
+//
+// An allowlist is only as good as its correspondence to reality, and this one is
+// hand-maintained so validate can stay fast. Without this check it is an unfalsifiable
+// claim — exactly the failure mode the attribute reference itself fell into, where
+// 8 of 11 documented attributes had stopped being real without anything noticing.
+//
+// Checked against the vendored bundle rather than a sibling client checkout, so it runs
+// wherever the repo does.
+func TestKnownAttributesAreReal(t *testing.T) {
+	bundle, err := os.ReadFile("internal/assets/client/tinkerdown-client.browser.js")
+	if err != nil {
+		t.Fatalf("read client bundle: %v", err)
+	}
+	goSrc := readProductionGo(t)
+
+	names := make([]string, 0, len(knownAttributes))
+	for name := range knownAttributes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if !appearsAsWholeName(name, bundle) && !appearsAsWholeName(name, goSrc) {
+			t.Errorf("allowlist entry %q is implemented by neither the client bundle nor Tinkerdown — "+
+				"validate would accept an attribute that does nothing", name)
+		}
+	}
+}
+
+func TestUnknownAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		markup   string
+		wantName string
+		wantHint string
+	}{
+		{
+			// The case this exists for: a plausible invention that validate would
+			// otherwise pass clean, leaving a generated page silently inert.
+			name:     "an invented attribute is reported",
+			markup:   `<table lvt-source="x" lvt-sortable></table>`,
+			wantName: "lvt-sortable",
+		},
+		{
+			name:     "a superseded name is reported with its replacement",
+			markup:   `<div lvt-scroll="bottom"></div>`,
+			wantName: "lvt-scroll",
+			wantHint: "use lvt-fx:scroll",
+		},
+		{
+			name:     "the fabricated lvt-value-* family is explained",
+			markup:   `<button lvt-value-name="#x"></button>`,
+			wantName: "lvt-value-name",
+			wantHint: "not implemented",
+		},
+		{name: "a real attribute passes", markup: `<table lvt-source="x" lvt-columns="a"></table>`},
+		{name: "a namespaced member passes", markup: `<form lvt-el:reset:on:success></form>`},
+		{name: "an arbitrary lvt-on event passes", markup: `<div lvt-on:mouseenter="Hover"></div>`},
+		{name: "data-lvt-* passes", markup: `<input data-lvt-force-update>`},
+		{name: "plain HTML is untouched", markup: `<div class="x" data-id="1"><input name="q"></div>`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			page := &Page{ServerBlocks: map[string]*ServerBlock{"b": {Content: tc.markup}}}
+			got := page.UnknownAttributes()
+
+			if tc.wantName == "" {
+				if len(got) != 0 {
+					t.Fatalf("expected no unknown attributes, got %+v", got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0].Name != tc.wantName {
+				t.Fatalf("expected %q reported, got %+v", tc.wantName, got)
+			}
+			if tc.wantHint != "" && !strings.Contains(got[0].Hint, tc.wantHint) {
+				t.Errorf("hint %q should mention %q — a diagnostic without a usable hint cannot be self-corrected against",
+					got[0].Hint, tc.wantHint)
+			}
+		})
+	}
+}
+
+func readProductionGo(t *testing.T) []byte {
+	t.Helper()
+	var all []byte
+	var walk func(string)
+	walk = func(dir string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			name := e.Name()
+			path := dir + "/" + name
+			switch {
+			case e.IsDir():
+				if name == "node_modules" || name == ".git" || name == ".worktrees" {
+					continue
+				}
+				walk(path)
+			case strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go"):
+				if b, err := os.ReadFile(path); err == nil {
+					all = append(all, b...)
+				}
+			}
+		}
+	}
+	walk(".")
+	return all
+}
+
+// appearsAsWholeName matches an attribute name at token boundaries. Substring matching
+// would report the dead lvt-scroll as live because data-lvt-scroll-sticky contains it.
+func appearsAsWholeName(name string, src []byte) bool {
+	s := string(src)
+	idx := 0
+	for {
+		rel := strings.Index(s[idx:], name)
+		if rel < 0 {
+			return false
+		}
+		start := idx + rel
+		end := start + len(name)
+		beforeOK := start == 0 || !isNameChar(rune(s[start-1]))
+		afterOK := end == len(s) || !isNameChar(rune(s[end]))
+		if beforeOK && afterOK {
+			return true
+		}
+		idx = start + 1
+	}
+}
+
+func isNameChar(r rune) bool {
+	return r == '-' || r == ':' || r == '_' ||
+		(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}


### PR DESCRIPTION
Third phase of M1 in the [ephemeral-UI reframe plan](docs/plans/2026-07-09-ephemeral-ui-reframe.md), following #301 and #302.

Makes `validate` a gate the generation loop can actually rely on, and gives the skill the workflow to use it.

## Pulled M2's attribute allowlist forward

The skill's loop is *"self-correct until validate is clean."* M0 Phase 2 proved clean meant almost nothing: a document using `lvt-filter`, `lvt-scroll` and a literal `lvt-totally-made-up` validated with **zero errors**, because unknown `lvt-*` attributes are emitted as inert HTML. A hallucinated attribute survived every iteration.

```
✗ unknown attribute "lvt-scroll" (use lvt-fx:scroll)
✗ unknown attribute "lvt-sortable"
```

Three design calls: the allowlist is hand-maintained so `validate` stays fast, but `TestKnownAttributesAreReal` checks every entry against the vendored bundle and Tinkerdown's source — without it, it'd be the same unfalsifiable claim that left 8 of 11 documented attributes stale. Namespaces are validated, members aren't (`lvt-on:` takes arbitrary DOM events; hard-coding member lists would create a second list to rot) — documented as a deliberate limit. Hints only where a real migration exists, because a guessed suggestion sends a self-correcting agent somewhere specific and *wrong*.

## Dogfooding found a third silent-failure class

I followed the workflow I'd just written and produced a page that **validated clean, summarised as privileged, served without error, and rendered nothing.** No JS exception, no server-log warning.

`lvt-*` markup only binds inside a ```lvt fence. In the markdown body it's ordinary HTML.

| "Validates clean but doesn't work" | |
|---|---|
| Unknown attributes | closed in this PR |
| Unapproved sources/actions | closed in #302 |
| **`lvt-*` outside a fence** | **closed in this PR** |

Fixed at the gate, not just in prose:

```
lvt-columns, lvt-source used outside an ```lvt block — this markup renders
but nothing binds to it; move it inside a ```lvt fence
```

I'd just closed the first class and believed that made the loop honest. "Clean" is a claim about *what was checked*, and each layer revealed another thing that wasn't. Only dogfooding exercised the whole chain rather than the part I was thinking about.

## Two operator decisions recorded

**Serve via `tinkerdown serve` on a scratch directory, not the playground.** The plan preferred the playground's `ParseString` path as "disk-free" — but it's an HTTP endpoint set needing a running server, a POST and a session ID, and it isn't disk-free anyway (`websocket.go:495` still writes each block to `/tmp`). A directory the operator can re-run and inspect is more useful, and if the UI proves worth keeping it already is a file.

**The validate loop stops after ~5 rounds.** A request still failing likely needs a capability the vocabulary lacks; saying so beats substituting attributes until something passes.

## A guard from M0 caught a regression from this phase

`vocabulary.go`'s migration table names dead attributes *to suggest replacements*, and `TestRemovedAttributesAreReallyGone` can't distinguish mentioning from implementing — it reported six dead attributes as live. Excluding the file would have been a blind spot, so the exclusion is paid for by `TestMigrationHintsAgreeWithRemovedLists`, which asserts every migrated-away name is recorded dead **and** genuinely absent from the shipped client. That second assertion guards a failure mode that didn't exist until this PR: a hint pointing at a *live* attribute would send an agent away from working code.

## Verification

- Full `GOWORK=off go test ./...` green including the root package with all 32 `//go:build !ci` e2e files (852s)
- **End-to-end:** a console generated by following the workflow serves and renders live sqlite data, verified by screenshot with zero JS exceptions
- Every new guard verified to fail when its condition is violated, not merely to pass today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018M9pJSPmG6i1D8s6rpEV4h