### PR TITLE
M1 Phase 6: capture the PII workflow as a skill + the /tinkerdown:save capability

### DIFF
--- a/captured_skills_test.go
+++ b/captured_skills_test.go
@@ -1,0 +1,61 @@
+package tinkerdown_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCapturedSkillsWellFormed checks the M1 Phase 6 skills — the captured
+// pii-access-approval workflow and the /tinkerdown:save capability — are
+// well-formed: valid frontmatter, and every repo path they point at exists.
+//
+// The pii-access-approval skill deliberately POINTS at examples/pii-access-approval/
+// rather than copying it (the artifacts are a committed source of truth; a copy
+// would be drift waiting to happen). This test is what makes that pointer safe: if
+// the example is moved or renamed, the skill's dead reference fails here.
+func TestCapturedSkillsWellFormed(t *testing.T) {
+	skills := []struct {
+		path string
+		refs []string // repo-relative paths the skill references, which must exist
+	}{
+		{
+			path: "skills/pii-access-approval/SKILL.md",
+			refs: []string{
+				"examples/pii-access-approval/tinkerdown.yaml",
+				"examples/pii-access-approval/app.md",
+				"examples/pii-access-approval/seed.sql",
+				"examples/pii-access-approval/README.md",
+			},
+		},
+		{
+			path: "skills/tinkerdown-save/SKILL.md",
+			refs: []string{
+				"skills/pii-access-approval",
+			},
+		},
+	}
+
+	for _, s := range skills {
+		content, err := os.ReadFile(s.path)
+		if err != nil {
+			t.Errorf("%s: %v", s.path, err)
+			continue
+		}
+		cs := string(content)
+
+		if !strings.HasPrefix(cs, "---") {
+			t.Errorf("%s: missing frontmatter (should start with ---)", s.path)
+		}
+		for _, key := range []string{"name:", "description:", "triggers:"} {
+			if !strings.Contains(cs, key) {
+				t.Errorf("%s: missing frontmatter field %q", s.path, key)
+			}
+		}
+		for _, ref := range s.refs {
+			if _, err := os.Stat(ref); err != nil {
+				t.Errorf("%s references %q, which does not exist: %v", s.path, ref, err)
+			}
+		}
+	}
+}

--- a/docs/guides/ai-generation.md
+++ b/docs/guides/ai-generation.md
@@ -12,24 +12,6 @@ The reason this works is the constraint: interactivity comes from a **fixed `lvt
 
 Tinkerdown ships the [`skills/tinkerdown`](../../skills/tinkerdown/) skill, whose default action **is** generation: it teaches an assistant the constrained attribute vocabulary and source types, then runs the loop — read the approved surface (a `tinkerdown.yaml` [`generation:` block](../reference/config.md#the-generation-block), if present) → write `app.md` using only approved sources/actions → `tinkerdown validate` and self-correct on its diagnostics → check the operation summary if the app is privileged → serve. You describe what you want in plain language; the assistant does the rest.
 
-## Ephemeral by default; persist on request
-
-The point of generating a UI in seconds is that it is **cheap to throw away** — the
-view you need for one question this week, deleted after. Most generated UIs are
-ephemeral: use them, discard them, regenerate from an up-to-date source of truth when
-the need returns. What is durable is the **substrate** — your approved data sources,
-policies, house style — not any individual screen.
-
-But some workflows recur. When a generated UI is worth keeping, you don't just save the
-`app.md` — you **capture the whole workflow as a re-runnable skill**, so it stands up
-again in seconds with no LLM generation at all. This is **opt-in and on request** —
-never automatic; ephemeral is the default. The captured skill bundles (or points at)
-the manifest, the golden `app.md`, and the fixtures, plus the steps to seed and serve.
-
-The [`skills/pii-access-approval`](../../skills/pii-access-approval/) skill is a worked
-example: the PII / data-export approval console, captured so an operator re-runs the
-working console directly rather than regenerating it.
-
 ### Example: Creating an App with Natural Language
 
 Simply describe what you want:
@@ -47,6 +29,26 @@ The AI will:
 2. Set up the SQLite database
 3. Generate the markdown with appropriate `lvt-*` attributes
 4. Configure sources in frontmatter
+
+## Ephemeral by default; persist on request
+
+The point of generating a UI in seconds is that it is **cheap to throw away** — the
+view you need for one question this week, deleted after. Most generated UIs are
+ephemeral: use them, discard them, regenerate from an up-to-date source of truth when
+the need returns. What is durable is the **substrate** — your approved data sources,
+policies, house style — not any individual screen.
+
+But some workflows recur. When a generated UI is worth keeping, you don't just save the
+`app.md` — you **capture the whole workflow as a re-runnable skill**, so it stands up
+again in seconds with no LLM generation at all. This is **opt-in and on request** —
+never automatic; ephemeral is the default. The captured skill bundles the manifest,
+the golden `app.md`, and the fixtures (or, when they already live at a committed path,
+points at them), plus the steps to seed and serve — see the
+[`/tinkerdown:save`](../../skills/tinkerdown-save/) capability.
+
+The [`skills/pii-access-approval`](../../skills/pii-access-approval/) skill is a worked
+example: the PII / data-export approval console, captured so an operator re-runs the
+working console directly rather than regenerating it.
 
 ## Prompt Tips
 

--- a/docs/guides/ai-generation.md
+++ b/docs/guides/ai-generation.md
@@ -10,9 +10,25 @@ The reason this works is the constraint: interactivity comes from a **fixed `lvt
 
 ## Using Claude Code Skills
 
-Tinkerdown ships one skill, [`skills/tinkerdown`](../../skills/tinkerdown/), which teaches an assistant the attribute vocabulary, the source types, and the worked examples. With it loaded, you don't invoke a command — you describe what you want in plain language and the assistant writes the markdown.
+Tinkerdown ships the [`skills/tinkerdown`](../../skills/tinkerdown/) skill, whose default action **is** generation: it teaches an assistant the constrained attribute vocabulary and source types, then runs the loop — read the approved surface (a `tinkerdown.yaml` [`generation:` block](../reference/config.md#the-generation-block), if present) → write `app.md` using only approved sources/actions → `tinkerdown validate` and self-correct on its diagnostics → check the operation summary if the app is privileged → serve. You describe what you want in plain language; the assistant does the rest.
 
-> **Generation workflow.** The loop today is: describe → the assistant writes `app.md` → `tinkerdown validate app.md` → fix any reported errors → `tinkerdown serve`. A dedicated generate skill that runs this loop end-to-end (including declaring which sources and actions an app is allowed to touch) is in development; see [the ephemeral-UI plan](../plans/2026-07-09-ephemeral-ui-reframe.md). Until it lands, run the steps above.
+## Ephemeral by default; persist on request
+
+The point of generating a UI in seconds is that it is **cheap to throw away** — the
+view you need for one question this week, deleted after. Most generated UIs are
+ephemeral: use them, discard them, regenerate from an up-to-date source of truth when
+the need returns. What is durable is the **substrate** — your approved data sources,
+policies, house style — not any individual screen.
+
+But some workflows recur. When a generated UI is worth keeping, you don't just save the
+`app.md` — you **capture the whole workflow as a re-runnable skill**, so it stands up
+again in seconds with no LLM generation at all. This is **opt-in and on request** —
+never automatic; ephemeral is the default. The captured skill bundles (or points at)
+the manifest, the golden `app.md`, and the fixtures, plus the steps to seed and serve.
+
+The [`skills/pii-access-approval`](../../skills/pii-access-approval/) skill is a worked
+example: the PII / data-export approval console, captured so an operator re-runs the
+working console directly rather than regenerating it.
 
 ### Example: Creating an App with Natural Language
 

--- a/docs/plans/2026-07-09-ephemeral-ui-reframe.md
+++ b/docs/plans/2026-07-09-ephemeral-ui-reframe.md
@@ -749,6 +749,8 @@ Sections marked `[skip on phase execution]` (Appendix A) are historical context 
 *New / changed risks.*
 - **New (low, portability): `sqlite3`-CLI seeding is not portable.** The example README and any captured skill that seeds via `sqlite3 … < seed.sql` fails where the CLI is absent (proven here). Mitigated with a `python3` fallback everywhere it appears; a `tinkerdown`-native seed/import command would be cleaner and is worth a follow-up (there is none today — `serve`/`build`/`validate`/`fix`/`new`/`cli` only).
 
+*Review-round fixes (PR #306).* The bot caught two things the blind test's own gap #4 predicted but my fix had not fully applied: (1) **the pii demo's `seed.sql` was not itself idempotent** — I had added the fresh-vs-persistent guidance to `/tinkerdown:save` (for future captures) but left the concrete artifact on plain `CREATE TABLE` + inserts, so re-running the "re-runnable" skill would silently duplicate every row. Fixed by making each table `DROP … IF EXISTS` then `CREATE` (a demo resets clean each run) — verified re-runnable (stable row counts on a second seed). The plan's earlier "fixed everywhere" claim was about the *sqlite3-portability*, not idempotency; corrected here. (2) A **heading-hierarchy bug** in `ai-generation.md` (the new H2 orphaned the "Example" H3 under it) — reordered. (3) The pii skill's "Run it" repeated the README's command block — now **points** at the README's steps (the pointing principle, applied to itself). The structural test's substring frontmatter check (a bot nit) is left as-is — sufficient for "is the field present".
+
 ---
 
 ### M2–M5 phases — outline only (expanded at milestone kickoff per convention 9)

--- a/docs/plans/2026-07-09-ephemeral-ui-reframe.md
+++ b/docs/plans/2026-07-09-ephemeral-ui-reframe.md
@@ -714,23 +714,40 @@ Sections marked `[skip on phase execution]` (Appendix A) are historical context 
 - Anthropic Claude skill-authoring best practices: progressive disclosure (concise `SKILL.md` + deep `reference.md`), explicit `name`/`description`/`triggers`, bundled examples + scripts, clear when-to-use, a validation step
 
 **Audit:**
-- [ ] **Design-ref completeness check.**
-- [ ] Decide the boundary between the *generic* `/tinkerdown` and the *specific* `skills/pii-access-approval/`: the latter bundles the manifest + golden `app.md` + fixtures + serve steps so re-running is near-instant and needs no LLM generation at all. Confirm it degrades cleanly if a team's data differs (parameterize the dataset/queue names).
-- [ ] `/tinkerdown:save` is a **namespaced sub-skill** (naming decided — see § Skills delivered + Appendix A). Define what it extracts from a conversation (the final `app.md`, the manifest deltas, the approve/deny wiring, the validate loop) and how it maps to `SKILL.md` + `reference.md` + `examples/`.
-- [ ] Confirm the generated skills pass the existing `skill_examples_test.go`-style structural contract (or an adapted one).
+- [x] **Design-ref completeness check.**
+- [x] Boundary between the generic `/tinkerdown` and the specific `skills/pii-access-approval/` — **operator/advisor correction: the captured skill POINTS at `examples/pii-access-approval/`, it does not bundle copies.** The plan's "bundle the manifest + golden `app.md` + fixtures" would copy a *committed source of truth* and then need a byte-match guard to keep the two in sync — which is the duplicate-the-source anti-pattern this milestone kept killing (Phase 5's corpus rot). A skill that ships in-repo to re-run an in-repo app should reference it. Degrades cleanly: if a team's data differs, edit `app.md` (a single human-editable file) or regenerate via `/tinkerdown`.
+- [x] `/tinkerdown:save` extracts: the final `app.md`, the manifest (if any — a frontmatter-sources app has none), the fixtures/seed, the stand-up steps, and the intent (→ description + triggers). **Bundle-vs-point rule:** bundle the artifacts into the skill when the UI was generated in an *ephemeral scratch dir* (the skill is then their only home — not duplication); point at the path when the artifacts are already *committed* (don't copy a source of truth).
+- [x] Structural contract: a new `TestCapturedSkillsWellFormed` (frontmatter present + every referenced repo path exists) — this is also the guard that makes the *pointer* safe (a moved/renamed example fails the test).
 
 **Implementation:**
-- [ ] `skills/pii-access-approval/` — `SKILL.md` (triggers: PII access, data-export approval, access request queue) + `reference.md` + `examples/` (the golden console) + the manifest + fixtures + a one-command serve. Re-running it stands up the working console in seconds.
-- [ ] `/tinkerdown:save` (namespaced sub-skill): given a completed generation session the user chose to persist, emit a well-formed skill (progressive disclosure, frontmatter, bundled example + validate step) following the Anthropic shape. Dogfood it by using it to (re)produce `skills/pii-access-approval/` from the Phase-4/5 session.
-- [ ] A short authoring guide (or extend `docs/guides/ai-generation.md`) documenting "ephemeral by default; persist on request by capturing the session as a skill via `/tinkerdown:save`" — the convention-13 doc.
+- [x] `skills/pii-access-approval/SKILL.md` — a **pointer skill** (triggers, when-to-use, what-it-does, stand-up steps) referencing `examples/pii-access-approval/`. No copied assets, no `reference.md`/`examples/` of its own (the example dir *is* the assets).
+- [x] `/tinkerdown:save` (`skills/tinkerdown-save/SKILL.md`) — the capture meta-skill: what to extract, how to produce `skills/<name>/`, the bundle-vs-point rule, and a required verify step. **Dogfooded via a *blind* agent** (given only the instructions + a synthetic "Team Standup Board" scratch session, never the golden PII skill): it produced a valid, validate-clean, correctly-*bundled* skill — and found four real instruction gaps, all fixed (see Learn).
+- [x] `docs/guides/ai-generation.md` — the convention-13 model (ephemeral by default; persist on request as a re-runnable skill), + corrected a stale note that the generate skill was "in development" (M1 Phase 3 shipped it).
+- [x] **(added) Portable seed guidance** in `/tinkerdown:save`, the pii skill, and the example README — the blind agent proved `sqlite3` is *absent* in this environment, so the literal `sqlite3 … < seed.sql` command fails; added a `python3` fallback.
 
 **Acceptance criteria:**
-- [ ] **Simplify:** `/simplify` + skill-asset pass.
-- [ ] **Unit/structural:** the two new skills pass the structural contract (frontmatter, required sections, referenced assets exist); a captured skill is well-formed.
-- [ ] **Integration:** run `skills/pii-access-approval/` end-to-end → working console in seconds; run skill-capture against the Phase-5 session → a valid skill that itself reproduces the console.
-- [ ] **E2E (chromedp, four-channel):** the re-run-from-skill path serves the console live; Approve/Deny work; screenshot.
+- [x] **Simplify:** prose/asset pass on both skills.
+- [x] **Unit/structural:** `TestCapturedSkillsWellFormed` (frontmatter + referenced paths exist); the blind capture produced a well-formed, validate-clean skill.
+- [x] **Integration:** the pii-access-approval skill's stand-up steps *are* `examples/pii-access-approval/`, which Phase 4's e2e already drives — serving the skill is serving the example. The `/tinkerdown:save` blind run stood up a working captured app (`tinkerdown validate` clean; seed → serve verified).
+- [x] ~~**E2E (chromedp, four-channel):** re-run-from-skill~~ — **struck as redundant** (advisor): the pointer skill serves the *same* artifacts Phase 4's four-channel e2e already exercises end to end. Re-running chromedp against identical bytes adds no coverage.
 
-**Learn:** what surprised us / plan drift / feed-forward to M5's Audit (the "save if the need recurs" gallery in M5 should store *skills*, not just `app.md` — connect the capture capability to the gallery) / new-or-changed risks.
+**Learn:**
+
+*What surprised us.*
+1. **The blind-agent verification — the honest test the advisor insisted on over self-grading — found the meta-skill's real weakness, and it wasn't the markup.** A blind agent given only the `/tinkerdown:save` instructions + a scratch session produced a valid, correctly-bundled skill, but reported four gaps, all in the *stand-up* half: (a) the seed command was unspecified and the natural `sqlite3 … < seed.sql` *fails* here because sqlite3 isn't installed (it fell back to `python3`); (b) `tinkerdown serve` never applies `seed.sql`, so seeding is a mandatory-but-implicit step; (c) no criterion for `--operator`/`--allow-exec`; (d) **fresh-vs-persistent DB is unresolved and contradicts the use case** — the user said "we run standup *every day*," yet `seed.sql` does `CREATE TABLE` + sample inserts, so a re-run errors or wipes real data. The mechanical capture (bundle-vs-point, what to extract, validate) was well-specified; the operational half was not. All four fixed.
+2. **I was one step from building the anti-pattern this milestone spent itself killing.** My first design was "bundle copies of the reference app into the skill + a test asserting the copies are byte-identical to the example." The advisor named it: two files that must always be equal should be *one* file — the byte-match guard is make-work around a duplication that shouldn't exist. The pointer skill is the correction.
+
+*PLAN.md drift fixed in this commit.*
+- The Implementation's "bundle the manifest + golden app.md + fixtures" is corrected to **point** (the artifacts are a committed source of truth). The bundle-vs-point *rule* is what generalizes — bundle ephemeral, point committed.
+- The re-run-from-skill chromedp e2e is struck as redundant (same artifacts as Phase 4).
+- The captured skill has no `reference.md`/`examples/` of its own — the referenced example dir is the assets; a parallel copy would be exactly the drift Phase 5 fixed.
+
+*Feed-forward to **M5**'s Audit.*
+- M5's "save if the need recurs" gallery should store the **captured skill** (the `/tinkerdown:save` output), not just the `app.md` — the capture capability *is* the gallery's unit. The bundle-vs-point rule carries over: a gallery of *ephemeral* captures bundles the artifacts; a captured *committed* app points. M5 should not re-litigate this.
+- The fresh-vs-persistent DB question `/tinkerdown:save` now *flags* (idempotent seed + seed-only-if-absent) is a real product decision M5's persistence model must settle — a saved workflow that recurs is persistent by nature.
+
+*New / changed risks.*
+- **New (low, portability): `sqlite3`-CLI seeding is not portable.** The example README and any captured skill that seeds via `sqlite3 … < seed.sql` fails where the CLI is absent (proven here). Mitigated with a `python3` fallback everywhere it appears; a `tinkerdown`-native seed/import command would be cleaner and is worth a follow-up (there is none today — `serve`/`build`/`validate`/`fix`/`new`/`cli` only).
 
 ---
 

--- a/examples/pii-access-approval/README.md
+++ b/examples/pii-access-approval/README.md
@@ -31,6 +31,8 @@ Nothing touches production and no data is real — `orders_pii` is synthetic.
 # 1. Build the fixture database from the seed script (synthetic data only).
 mkdir -p data
 sqlite3 data/access.db < seed.sql
+# ...or, if the sqlite3 CLI isn't installed:
+# python3 -c "import sqlite3; sqlite3.connect('data/access.db').executescript(open('seed.sql').read())"
 
 # 2. Serve. --operator is the approver identity written into the audit trail.
 tinkerdown serve . --operator you@corp.example

--- a/examples/pii-access-approval/seed.sql
+++ b/examples/pii-access-approval/seed.sql
@@ -4,8 +4,15 @@
 -- fabricated ("*.test" is a reserved non-routable TLD). This makes the export
 -- job genuinely run against "PII" while touching no real person's data.
 --
+-- Re-runnable: each table is DROP-then-CREATE, so re-seeding resets to a clean
+-- demo state — running it again does not error on existing tables or duplicate
+-- rows. This is a demo (fresh each run); a persistent workflow would seed once.
+--
 -- Build the database:  sqlite3 data/access.db < seed.sql
+--   (or, without the sqlite3 CLI:
+--    python3 -c "import sqlite3; sqlite3.connect('data/access.db').executescript(open('seed.sql').read())")
 
+DROP TABLE IF EXISTS access_requests;
 CREATE TABLE access_requests (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     requester   TEXT NOT NULL,
@@ -22,6 +29,7 @@ CREATE TABLE access_requests (
     created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
+DROP TABLE IF EXISTS audit_log;
 CREATE TABLE audit_log (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     ts         TEXT,
@@ -35,6 +43,7 @@ CREATE TABLE audit_log (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
+DROP TABLE IF EXISTS datasets;
 CREATE TABLE datasets (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     name        TEXT NOT NULL,
@@ -42,6 +51,7 @@ CREATE TABLE datasets (
     description TEXT
 );
 
+DROP TABLE IF EXISTS orders_pii;
 CREATE TABLE orders_pii (
     id     INTEGER PRIMARY KEY AUTOINCREMENT,
     name   TEXT,
@@ -49,6 +59,7 @@ CREATE TABLE orders_pii (
     amount REAL
 );
 
+DROP TABLE IF EXISTS exports;
 CREATE TABLE exports (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     request_id  INTEGER,
@@ -72,6 +83,7 @@ INSERT INTO datasets (name, sensitivity, description) VALUES
 -- redefine the approved `access_requests` source to point here must be ignored,
 -- because approval pins the source against page-level redefinition. Its single
 -- row is deliberately distinguishable from the approved queue's rows.
+DROP TABLE IF EXISTS decoy_requests;
 CREATE TABLE decoy_requests (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     requester   TEXT NOT NULL,

--- a/skills/pii-access-approval/SKILL.md
+++ b/skills/pii-access-approval/SKILL.md
@@ -42,20 +42,14 @@ variant with the `/tinkerdown` skill against your own manifest.
 ## Run it
 
 The artifacts live at [`examples/pii-access-approval/`](../../examples/pii-access-approval/)
-— the workspace manifest (`tinkerdown.yaml`), the console (`app.md`), and the
-synthetic fixtures (`seed.sql`). Stand it up:
+— the workspace manifest (`tinkerdown.yaml`), the console (`app.md`), and the synthetic
+fixtures (`seed.sql`). Its
+[README's **Run it** section](../../examples/pii-access-approval/README.md#run-it) has
+the exact steps (kept in one place so they cannot drift). In short: from that directory,
+build `data/access.db` from `seed.sql` — the seed is **re-runnable**, it resets to a
+clean demo state each run — then serve with an approver identity:
 
 ```bash
-cd examples/pii-access-approval
-
-# 1. Build the fixture database from the seed script (synthetic data only).
-mkdir -p data
-sqlite3 data/access.db < seed.sql
-# ...or, if the sqlite3 CLI isn't installed:
-# python3 -c "import sqlite3; sqlite3.connect('data/access.db').executescript(open('seed.sql').read())"
-
-# 2. Serve. --operator is the approver identity written into the audit trail
-#    (this app writes it into the audit records, so the flag matters here).
 tinkerdown serve . --operator you@corp.example
 ```
 

--- a/skills/pii-access-approval/SKILL.md
+++ b/skills/pii-access-approval/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pii-access-approval
+description: Stand up the PII / data-export access-approval console in seconds — a governed request queue with bounded, audited Approve/Deny. A saved, re-runnable workflow; no LLM generation needed.
+triggers:
+  - PII access approval
+  - data-export approval
+  - access request queue
+  - approve access requests
+  - sensitive data export console
+---
+
+# PII / Data-Export Access Approval — saved workflow
+
+This is a **captured, re-runnable workflow**: the reference console for approving
+requests to export sensitive data. It removes the real friction of *Slack-ping
+someone with prod access → they hand-run a query → weak audit trail*. Because the
+whole app already exists as a single markdown file plus a manifest, standing it up
+takes seconds and needs **no LLM generation** — you run it, you don't regenerate it.
+
+This is the "keep it — the need recurs" path of the ephemeral-UI model: the
+individual UI is throwaway, but a workflow worth keeping is captured as a skill and
+re-run directly.
+
+## When to use
+
+Use this when someone needs to review and approve requests for access to sensitive
+data — a PII export, a scoped prod-DB read — with a durable, auditable decision
+trail. If the team's data or fields differ, treat the served console as the starting
+point and edit `app.md` (it is a single, human-editable file), or regenerate a
+variant with the `/tinkerdown` skill against your own manifest.
+
+## What it does
+
+- A **pending-requests queue** with the full decision context (requester, dataset,
+  bounded scope, justification, TTL, sensitivity).
+- **Approve** → a bounded, server-authoritative export (the row cap is read from the
+  request row, not the client) **plus** a durable audit record, committed atomically.
+- **Deny** → records the decision; grants nothing.
+- **Governed writes only**: the UI-bound sources are read-only; every mutation goes
+  through a named, audited action, so a requester cannot forge a decision.
+
+## Run it
+
+The artifacts live at [`examples/pii-access-approval/`](../../examples/pii-access-approval/)
+— the workspace manifest (`tinkerdown.yaml`), the console (`app.md`), and the
+synthetic fixtures (`seed.sql`). Stand it up:
+
+```bash
+cd examples/pii-access-approval
+
+# 1. Build the fixture database from the seed script (synthetic data only).
+mkdir -p data
+sqlite3 data/access.db < seed.sql
+# ...or, if the sqlite3 CLI isn't installed:
+# python3 -c "import sqlite3; sqlite3.connect('data/access.db').executescript(open('seed.sql').read())"
+
+# 2. Serve. --operator is the approver identity written into the audit trail
+#    (this app writes it into the audit records, so the flag matters here).
+tinkerdown serve . --operator you@corp.example
+```
+
+Open the served URL, review a pending request's scope, and click **Approve** or
+**Deny**. The request leaves the *Pending* view and a row appears in the audit trail.
+
+## How it works
+
+See [`examples/pii-access-approval/README.md`](../../examples/pii-access-approval/README.md)
+for the full walkthrough — the manifest's approved surface, the atomic multi-statement
+actions, the server-authoritative bounded export, and the governed-writes design. The
+console's whole framework leg (parse → first render → live WebSocket) is ~17 ms, so the
+time cost is the human's review, not the runtime.

--- a/skills/tinkerdown-save/SKILL.md
+++ b/skills/tinkerdown-save/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: tinkerdown-save
+description: Capture an ephemeral Tinkerdown UI you just generated into a durable, re-runnable Claude Code skill — so a workflow worth keeping re-runs in seconds without regenerating. Invoked on request as /tinkerdown:save; opt-in, never automatic.
+triggers:
+  - save this UI
+  - keep this app
+  - persist this workflow
+  - make this reusable
+  - turn this into a skill
+  - /tinkerdown:save
+---
+
+# /tinkerdown:save — capture an ephemeral UI as a reusable skill
+
+Generated UIs are **ephemeral by default** — use them, throw them away, regenerate
+from an up-to-date source of truth when the need returns. But some workflows recur.
+When the user decides one is worth keeping, this skill distils the just-completed
+generation session into a durable, re-runnable skill, so it stands up again in
+seconds with **no LLM generation at all**.
+
+## When to use
+
+Only when **the user asks to keep / save / persist** a UI generated earlier in the
+conversation. This is opt-in and on request — never fire it automatically after a
+generation. Ephemeral is the default; capture is the exception.
+
+Do not use it to save an app that does not yet work: the thing being captured must
+already `tinkerdown validate` clean and serve. Capture preserves a working artifact;
+it does not fix a broken one.
+
+## What to extract from the session
+
+Look back over the conversation for the working UI the user produced and gather:
+
+1. **The `app.md`** — the final, validated document that was served.
+2. **The manifest** — the `tinkerdown.yaml` it ran against (its approved sources and
+   named actions), if there was one. A plain app with sources in frontmatter has no
+   separate manifest; note that.
+3. **The fixtures / data setup** — the schema + seed (a `seed.sql`, a `.db`, or the
+   steps that created the data). Synthetic/sample data, not anything real.
+4. **The stand-up steps** — how it was served: seeding the database, the
+   `tinkerdown serve …` command, any `--operator` / `--allow-exec` flags.
+5. **The intent** — what the UI is *for*, in one line. This becomes the skill's
+   `description` and `triggers`.
+
+## How to produce the skill
+
+Create `skills/<kebab-name>/` at the repo's top level (alongside the other skill
+directories) and write a `SKILL.md` with:
+
+- **Frontmatter:** `name` (kebab-case, derived from the app's title), a one-line
+  `description` (what it stands up + that it re-runs without generation), and 3–6
+  `triggers` (the phrases someone would say when they need this workflow).
+- **When to use** — the situation this workflow serves; when to regenerate instead.
+- **What it does** — the UI's behavior in a few bullets.
+- **Run it** — the exact stand-up steps (see below), copy-pasteable.
+
+### Writing the "Run it" steps — the part that is easy to get wrong
+
+The blind test of this skill showed the stand-up steps are where a captured skill
+breaks, not the markup. Get these three right:
+
+- **Seeding is a real step, and `tinkerdown serve` does not do it.** Serving starts
+  the server; it never applies `seed.sql`. A writable `sqlite` source *does*
+  auto-create its table on first write, so an app works **empty** with no seed at
+  all — seed only when the workflow needs pre-loaded rows (a queue to review, a
+  catalog). When you do seed, do not assume `sqlite3` is installed (it often is not).
+  Give a portable command:
+
+  ```bash
+  # if the sqlite3 CLI is available:
+  sqlite3 data/app.db < seed.sql
+  # otherwise (python3 is almost always present):
+  python3 -c "import sqlite3; sqlite3.connect('data/app.db').executescript(open('seed.sql').read())"
+  ```
+
+- **Decide fresh-vs-persistent and say so.** A demo re-seeds fresh each run; a workflow
+  the user keeps ("we do this every day") must **persist** — so make `seed.sql`
+  idempotent (`CREATE TABLE IF NOT EXISTS`) and seed **only if the database does not
+  already exist**, so a re-run keeps prior data instead of erroring on the existing
+  table or wiping it. State which model the skill uses.
+
+- **Flags follow the app, not habit.** Add `--operator you@example.com` only if the
+  app writes an operator identity (a governed action referencing `:operator`, e.g. an
+  audit trail). Add `--allow-exec` only if the app uses an `exec` source or action.
+  Otherwise omit both. (`serve` always has *some* operator identity — the flag only
+  sets it.)
+
+**Bundle vs. point — the rule that avoids duplication:**
+
+- **Bundle** the artifacts into `skills/<name>/` (`app.md`, `tinkerdown.yaml`,
+  `seed.sql`) when the UI was generated in a scratch/ephemeral directory that will be
+  thrown away — the skill is then their only home, so copies are not duplication.
+- **Point** at the existing path instead (do **not** copy) when the artifacts already
+  live at a stable, committed location in the repo (e.g. under `examples/`). Copying a
+  committed source of truth just creates two files that must stay identical — which is
+  drift waiting to happen. Reference the committed path from the skill.
+
+## Verify before finishing (required)
+
+A captured skill nobody trusts is worse than none. Confirm:
+
+1. `tinkerdown validate <the skill's app.md, or the path it points at>` passes clean.
+2. Every path the `SKILL.md` references actually exists.
+3. The stand-up steps are complete — a fresh reader could seed and serve from them
+   alone, with nothing implicit.
+
+If validation fails, the underlying app was not actually working — fix that first (or
+tell the user it is not ready to save), rather than capturing a broken artifact.
+
+## Example of a captured skill
+
+[`skills/pii-access-approval`](../pii-access-approval/) is a worked result of this
+capability: the PII / data-export approval console, captured as a re-runnable skill.
+Its artifacts already live under `examples/`, so it **points** at them rather than
+copying — the "committed source" case above.


### PR DESCRIPTION
The last M1 phase — the "keep it, the need recurs" path of the ephemeral-UI model. Two skills + the convention-13 doc.

## `skills/pii-access-approval/` — a pointer skill

A captured, re-runnable workflow: the PII / data-export approval console stands up in seconds with no LLM generation. It **points at** `examples/pii-access-approval/` (triggers, when-to-use, stand-up steps) rather than copying it.

The plan said "bundle the manifest + golden `app.md` + fixtures." That would copy a **committed source of truth** and then need a byte-match guard to keep the two in sync — the duplicate-the-source anti-pattern this milestone kept killing (Phase 5's corpus rot). A skill that ships in-repo to re-run an in-repo app should reference it. Zero copied assets, zero drift.

## `/tinkerdown:save` — the capture meta-skill, blind-verified

A skill that writes skills: given a session where the user generated + served an ephemeral UI they now want to keep, it distils it into a durable, re-runnable skill. It defines what to extract, how to produce `skills/<name>/`, and the **bundle-vs-point rule** (bundle *ephemeral scratch* artifacts — the skill is their only home; point at *committed* sources — don't duplicate), plus a required verify step.

**Verified by a blind agent** — given only the instructions + a synthetic "Team Standup Board" scratch session (never the golden PII skill), to avoid grading my own output. It produced a valid, validate-clean, correctly-**bundled** skill — and found **4 real gaps**, all fixed:
1. The seed command was unspecified, and the natural `sqlite3 … < seed.sql` **fails** where sqlite3 isn't installed (proven in CI's environment — it fell back to `python3`). Added a `python3` fallback everywhere the command appears.
2. `tinkerdown serve` never applies `seed.sql` — seeding is a mandatory-but-implicit step.
3. No criterion for `--operator`/`--allow-exec`.
4. **Fresh-vs-persistent DB** was unresolved and contradicts the recurring use case ("we run standup every day"): `seed.sql` did `CREATE TABLE` + sample inserts, so a re-run errors or wipes real data → now idempotent seed + seed-only-if-absent.

This is the value of the blind test over self-dogfooding: the mechanical capture (bundle-vs-point, what to extract, validate) was well-specified; the *operational* half wasn't, and only an independent run surfaced it.

## `docs/guides/ai-generation.md`

The convention-13 model — ephemeral by default; persist on request as a re-runnable skill — plus a corrected stale note that the generate skill was "in development" (M1 Phase 3 shipped it).

## Tests / scope

- `captured_skills_test.go` — structural (frontmatter present + every referenced repo path exists); also the guard that makes the pointer safe (a moved example fails it).
- **No re-run-from-skill chromedp e2e** — struck as redundant: the pointer skill serves the *same* artifacts Phase 4's four-channel e2e already drives end to end.

## Verification

`GOWORK=off go test -count=1 -timeout 60m ./...` green (17 ok packages, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018M9pJSPmG6i1D8s6rpEV4h