### PR TITLE
fix(release): env-bash shebang so release.sh runs on non-FHS systems (NixOS)

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Tinkerdown Release Script


### PR DESCRIPTION
## Problem

`release.sh` starts with `#!/bin/bash`. On systems without a `/bin/bash` — notably **NixOS**, where bash lives under `/run/current-system/sw/bin` — running `./release.sh <version>` fails with:

```
bad interpreter: /bin/bash: no such file or directory
```

and creates **no tag**, so the release silently no-ops. This bit the **v0.4.0** cut: the script had to be re-run via an explicit `/run/current-system/sw/bin/bash ./release.sh` to actually tag.

## Fix

One line: `#!/bin/bash` → `#!/usr/bin/env bash`, which resolves bash via `PATH` and works on NixOS and standard FHS systems alike.

## Verification

- `bash -n release.sh` — syntax clean.
- `./release.sh` (no args) — prints usage via the new shebang (confirms it resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018M9pJSPmG6i1D8s6rpEV4h